### PR TITLE
Define bitfield type

### DIFF
--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -16,8 +16,8 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "rails",        "~> 3.2.22"
-  s.add_dependency "hobo_support", "2.0.1"
+  s.add_dependency "rails",            "~> 3.2.22"
+  s.add_dependency "hobo_support",     "2.0.1"
   s.add_dependency "large_text_field", "0.0.2"
 
   s.add_development_dependency "invoca-utils", "0.0.2"

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.summary     = "A no-sql style document store using mysql"
   s.description = "Store hashes of attributes on active record models.  Add attributes without requiring migrations"
 
-  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.rdoc"]
+  s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
   s.add_dependency "rails",            "~> 3.2.22"

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -1,3 +1,5 @@
+require "aggregate/bitfield"
+
 require "aggregate/attribute/base"
 require "aggregate/attribute/builtin"
 require "aggregate/attribute/string"
@@ -11,6 +13,7 @@ require "aggregate/attribute/nested_aggregate"
 require "aggregate/attribute/schema_version"
 require "aggregate/attribute/foreign_key"
 require "aggregate/attribute/list"
+require "aggregate/attribute/bitfield"
 
 require "aggregate/engine"
 require "aggregate/aggregate_store"

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -2,7 +2,7 @@ class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
 
   def self.available_options
     super + [
-      :limit #
+      :limit
     ]
   end
 

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -1,0 +1,26 @@
+class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
+
+  def self.available_options
+    super + [
+      :limit #
+    ]
+  end
+
+  def from_value(value)
+    klass.new(value || "")
+  end
+
+  def from_store(value)
+    klass.new(value)
+  end
+
+  def to_store(value)
+    value.to_s if value
+  end
+
+  private
+
+  def klass
+    @klass ||= options[:limit] ? Aggregate::Bitfield.limit(options[:limit]) : Aggregate::Bitfield
+  end
+end

--- a/lib/aggregate/attribute_handler.rb
+++ b/lib/aggregate/attribute_handler.rb
@@ -9,7 +9,8 @@ module Aggregate
       'boolean'   => Aggregate::Attribute::Boolean,
       'enum'      => Aggregate::Attribute::Enum,
       'datetime'  => Aggregate::Attribute::DateTime,
-      'decimal'   => Aggregate::Attribute::Decimal
+      'decimal'   => Aggregate::Attribute::Decimal,
+      'bitfield'  => Aggregate::Attribute::Bitfield
     }
 
     def initialize(name, class_name, options)

--- a/lib/aggregate/bitfield.rb
+++ b/lib/aggregate/bitfield.rb
@@ -15,9 +15,7 @@ module Aggregate
 
     def []=(index, value)
       check_index_limit(index)
-      if index > @string.size
-        @string = @string.ljust(index)
-      end
+      @string = @string.ljust(index)
       @string[index] = to_character(value)
     end
 
@@ -48,9 +46,7 @@ module Aggregate
         true
       when 'f'
         false
-      when ' '
-        nil
-      when nil
+      when ' ', nil
         nil
       else
         raise "Unexpeced value in bitfield: (#{@string.inspect})"

--- a/lib/aggregate/bitfield.rb
+++ b/lib/aggregate/bitfield.rb
@@ -1,0 +1,81 @@
+# A string representation of a fixed length array of nillable booleans.
+# A length limited version of the class is created by calling the limit method.
+module Aggregate
+  class Bitfield
+    include Comparable
+
+    def initialize(string_form)
+      @string = string_form
+    end
+
+    def [](index)
+      check_index_limit(index)
+      to_boolean(@string[index])
+    end
+
+    def []=(index, value)
+      check_index_limit(index)
+      if index > @string.size
+        @string = @string.ljust(index)
+      end
+      @string[index] = to_character(value)
+    end
+
+    def to_s
+      @string.rstrip
+    end
+
+    def <=>(other)
+      self.to_s <=> other.to_s
+    end
+
+
+    private
+    def to_character(boolean)
+      case boolean
+      when true
+        "t"
+      when false
+        "f"
+      when nil
+        " "
+      end
+    end
+
+    def to_boolean(character)
+      case character
+      when 't'
+        true
+      when 'f'
+        false
+      when ' '
+        nil
+      when nil
+        nil
+      else
+        raise "Unexpeced value in bitfield: (#{@string.inspect})"
+      end
+    end
+
+    protected
+    def check_index_limit(index)
+      # Derived classes overwrite this to enforce their limits
+    end
+
+    def self.limit(limit)
+      limited_class = "Aggregate::Bitfield_Limit_#{limit}"
+      unless Object.const_defined?(limited_class)
+        instance_eval <<-EOC
+          class #{limited_class} < Aggregate::Bitfield
+            def check_index_limit(index)
+              if index >= #{limit}
+                raise ArgumentError, "index out of bounds, index(\#{index}) >= limit(#{limit})"
+              end
+            end
+          end
+        EOC
+      end
+      limited_class.constantize
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,6 +13,12 @@
 
 ActiveRecord::Schema.define(:version => 20160316211434) do
 
+  create_table "documents", :force => true do |t|
+    t.string   "name"
+    t.datetime "created_at", :null => false
+    t.datetime "updated_at", :null => false
+  end
+
   create_table "large_text_fields", :force => true do |t|
     t.string  "field_name",                     :null => false
     t.text    "value",      :limit => 16777215

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -9,6 +9,10 @@ require "shoulda"
 require "minitest/unit"
 require "pry"
 
+Rails.backtrace_cleaner.remove_silencers!
+# Rails.backtrace_cleaner.add_silencer { |line| line =~ /active_support/}
+# Rails.backtrace_cleaner.add_silencer { |line| line =~ /shoulda/}
+
 def sample_passport
   Passport.create!(
     name: "Millie",

--- a/test/unit/attribute/bitfield_test.rb
+++ b/test/unit/attribute/bitfield_test.rb
@@ -1,0 +1,19 @@
+require_relative '../../test_helper'
+
+class Aggregate::Attribute::BitfieldTest < ActiveSupport::TestCase
+
+  should "handle bitfield" do
+    ad = Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4)
+
+    result = ad.from_value("tf t")
+    assert_equal Aggregate::Bitfield.limit(4).new("tf t"), result
+    assert_equal true, result[0]
+    assert_equal false, result[1]
+    assert_equal nil, result[2]
+    assert_equal true, result[3]
+
+    assert_equal Aggregate::Bitfield.limit(4).new("tf t"), ad.from_store("tf t")
+    assert_equal "tf t",    ad.to_store(Aggregate::Bitfield.limit(4).new("tf t"))
+  end
+
+end

--- a/test/unit/bitfield_test.rb
+++ b/test/unit/bitfield_test.rb
@@ -21,6 +21,7 @@ class Aggregate::BitfieldTest < ActiveSupport::TestCase
       bitfield = Aggregate::Bitfield.new("")
 
       bitfield[10] = true
+      assert_equal [nil]*10+[true], (0..10).map { |i| bitfield[i] }
     end
 
     should "trim trailing nils when reporting the string value" do
@@ -40,23 +41,19 @@ class Aggregate::BitfieldTest < ActiveSupport::TestCase
       should "warn when reading from to bitfields outside the limit" do
         bitfield = Aggregate::Bitfield.limit(5).new("")
 
-        begin
+        ex = assert_raises ArgumentError do
           bitfield[5]
-          fail "Didn't raise like I expected"
-        rescue ArgumentError => ex
-          assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
         end
+        assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
       end
 
       should "warn when writing to bitfields outside the limit" do
         bitfield = Aggregate::Bitfield.limit(5).new("")
 
-        begin
+        ex = assert_raises ArgumentError do
           bitfield[5] = false
-          fail "Didn't raise like I expected"
-        rescue ArgumentError => ex
-          assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
         end
+        assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
       end
 
 

--- a/test/unit/bitfield_test.rb
+++ b/test/unit/bitfield_test.rb
@@ -1,0 +1,85 @@
+require_relative '../test_helper'
+
+class Aggregate::BitfieldTest < ActiveSupport::TestCase
+  context "bitfield" do
+    should "support array operations" do
+      bitfield = Aggregate::Bitfield.new("")
+
+      bitfield[0] = true
+      assert_equal true, bitfield[0]
+
+      bitfield[1] = false
+      assert_equal false, bitfield[1]
+
+      bitfield[2] = nil
+      assert_equal nil, bitfield[2]
+
+      assert_equal "tf", bitfield.to_s
+    end
+
+    should "fill in details indexing past the length of the string" do
+      bitfield = Aggregate::Bitfield.new("")
+
+      bitfield[10] = true
+    end
+
+    should "trim trailing nils when reporting the string value" do
+      bitfield = Aggregate::Bitfield.new("")
+      bitfield[10] = nil
+      assert_equal "", bitfield.to_s
+    end
+
+    context "length limited classes" do
+      should "allow values below the limit" do
+        bitfield = Aggregate::Bitfield.limit(10).new("")
+
+        bitfield[9] = true
+        assert_equal true, bitfield[9]
+      end
+
+      should "warn when reading from to bitfields outside the limit" do
+        bitfield = Aggregate::Bitfield.limit(5).new("")
+
+        begin
+          bitfield[5]
+          fail "Didn't raise like I expected"
+        rescue ArgumentError => ex
+          assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
+        end
+      end
+
+      should "warn when writing to bitfields outside the limit" do
+        bitfield = Aggregate::Bitfield.limit(5).new("")
+
+        begin
+          bitfield[5] = false
+          fail "Didn't raise like I expected"
+        rescue ArgumentError => ex
+          assert_equal "index out of bounds, index(5) >= limit(5)", ex.message
+        end
+      end
+
+
+      should "allow comparison between bitfields" do
+        first = Aggregate::Bitfield.limit(5).new("")
+        second = Aggregate::Bitfield.limit(5).new("")
+
+        assert_equal first, second
+
+        first[0] = true
+        assert_not_equal first, second
+      end
+
+      should "allow comparision between bitfields of different limits" do
+        first = Aggregate::Bitfield.limit(5).new("")
+        second = Aggregate::Bitfield.limit(50).new("")
+
+        assert_equal first, second
+
+        first[0] = true
+        assert_not_equal first, second
+      end
+    end
+  end
+
+end

--- a/test/unit/combined_string_field_test.rb
+++ b/test/unit/combined_string_field_test.rb
@@ -75,11 +75,10 @@ class Aggregate::CombinedStringFieldTest < ActiveSupport::TestCase
     end
 
     should "raise if an error if a newline is used in an input" do
-      begin
+      ex = assert_raises ArgumentError do
         @instance.first = "abc\n123"
-      rescue ArgumentError => ex
-        assert ex.message =~ /Cannot store newlines in combined fields storing \"abc\\n123\" in first/
       end
+      assert ex.message =~ /Cannot store newlines in combined fields storing \"abc\\n123\" in first/
     end
 
     should "report if an attribute changed" do

--- a/test/unit/combined_string_field_test.rb
+++ b/test/unit/combined_string_field_test.rb
@@ -78,7 +78,7 @@ class Aggregate::CombinedStringFieldTest < ActiveSupport::TestCase
       begin
         @instance.first = "abc\n123"
       rescue ArgumentError => ex
-        ex.message =~ /Cannot store newlines in combined fields storing \"abc\\n123\" in first/
+        assert ex.message =~ /Cannot store newlines in combined fields storing \"abc\\n123\" in first/
       end
     end
 


### PR DESCRIPTION
Hey @c-simmons  - you touched it last so you win!

I have a project that is going to store 100 of booleans in an aggregate.  This was going to take about 2K when marshaled because of the JSON overhead.  Instead, I added a bitfield type which allows them to be stored in a single string attribute.  This is almost a 20x space savings!

Please let me know if you have any questions. 