### PR TITLE
add from_json method and tests

### DIFF
--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -35,6 +35,15 @@ module Aggregate
       new.tap { |instance| instance._set_store(decoded_aggregate_store) }
     end
 
+    def self.from_json(hash)
+      decoded_hash = hash.presence && ActiveSupport::JSON.decode(hash)
+      new.tap { |instance| instance._set_store(decoded_hash.presence, false) }
+    end
+
+    def to_json
+      ActiveSupport::JSON.encode(to_store)
+    end
+
     def self.attribute(*args)
       aggregate_attribute(*args)
     end
@@ -69,9 +78,9 @@ module Aggregate
       attribute.to_s.humanize
     end
 
-    def _set_store(decoded_aggregate_store)
+    def _set_store(decoded_aggregate_store, from_store = true)
       self.decoded_aggregate_store = decoded_aggregate_store
-      @loaded_from_store = true
+      @loaded_from_store = from_store
     end
 
     private


### PR DESCRIPTION
@mikeweaver @codyjca please review 

For serialization we can use [`to_store`](https://github.com/Invoca/aggregate/blob/1e8ac42b534f6343f0e8267cb3e56aa0c5d02cd9/lib/aggregate/aggregate_store.rb#L66), so no change in the gem.

I added `from_json` method for deserialization, but I need to mention that we already had two methods:
The default initializer can take a hash as parameter but it will raise an exception if there is a key in the hash that does not exist as an attribute ([added a test for that](https://github.com/Invoca/aggregate/compare/98/t/STORY-3970_to_from_json?expand=1#diff-5293b6e4f7bca4190efe86a0f98c6046R33))
The second method is [`from_store`](https://github.com/Invoca/aggregate/blob/1e8ac42b534f6343f0e8267cb3e56aa0c5d02cd9/lib/aggregate/base.rb#L34) but this one will add the hash with invalid keys (if any) to `decoded_aggregate_store` (not sure what is the intended usage for it - I wasn't able to find any usage in our web repo)

Question: Should we update any of the existing behavior or use the new method? 
In case we want to use existing methods, we need to get in touch with Bob probably and see if he can help us clarify the intended usage.
Thanks