### PR TITLE
99/a/story 3958 customer data phase 1

### DIFF
--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -65,7 +65,11 @@ module Aggregate
 
     def to_store
       self.class.aggregated_attributes.build_hash do |aa|
-        [aa.name, aa.to_store(load_aggregate_attribute(aa))]
+        agg_value = load_aggregate_attribute(aa)
+        # If schema versioning is in use, write out the values (Some clients depend on this)
+        if respond_to?(:data_schema_version) || agg_value != aa.default
+          [aa.name, aa.to_store(agg_value)]
+        end
       end
     end
 

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -66,8 +66,10 @@ module Aggregate
     def to_store
       self.class.aggregated_attributes.build_hash do |aa|
         agg_value = load_aggregate_attribute(aa)
-        # If schema versioning is in use, write out the values (Some clients depend on this)
-        if respond_to?(:data_schema_version) || agg_value != aa.default
+
+        # Optimization: only write out values if they are not nil, if there is no schema migration and
+        # the default value is nil. (Schema migrations and defaults depend on writing the value.)
+        if respond_to?(:data_schema_version) || !aa.default.nil? || !agg_value.nil?
           [aa.name, aa.to_store(agg_value)]
         end
       end

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -15,7 +15,16 @@ class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
   end
 
   def to_store(value)
-    value.to_s if value
+    value.to_s if value && value != ""
+  end
+
+  def default
+    klass.new("")
+  end
+
+  # Overrides default
+  def validation_errors(value)
+    []
   end
 
   private

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -11,7 +11,7 @@ class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
   end
 
   def from_store(value)
-    klass.new(value)
+    klass.new(value || "")
   end
 
   def to_store(value)

--- a/lib/aggregate/bitfield.rb
+++ b/lib/aggregate/bitfield.rb
@@ -49,7 +49,7 @@ module Aggregate
       when ' ', nil
         nil
       else
-        raise "Unexpeced value in bitfield: (#{@string.inspect})"
+        raise "Unexpected value in bitfield: (#{@string.inspect})"
       end
     end
 

--- a/test/dummy/app/models/passport.rb
+++ b/test/dummy/app/models/passport.rb
@@ -12,7 +12,7 @@ class Passport < ActiveRecord::Base
   aggregate_attribute :state,            :string,   required: true
   aggregate_attribute :birthdate,        :datetime, required: true
   aggregate_attribute :height,           :decimal
-  aggregate_attribute :weight,           :decimal
+  aggregate_attribute :weight,           :decimal, default: 100
   aggregate_attribute :photo,            "PassportPhoto"
   aggregate_has_many  :foreign_visits,   "ForeignVisit"
   aggregate_attribute :stamps,           :bitfield, limit: 10

--- a/test/dummy/app/models/passport.rb
+++ b/test/dummy/app/models/passport.rb
@@ -15,4 +15,6 @@ class Passport < ActiveRecord::Base
   aggregate_attribute :weight,           :decimal
   aggregate_attribute :photo,            "PassportPhoto"
   aggregate_has_many  :foreign_visits,   "ForeignVisit"
+  aggregate_attribute :stamps,           :bitfield, limit: 10
+
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -13,12 +13,6 @@
 
 ActiveRecord::Schema.define(:version => 20160316211434) do
 
-  create_table "documents", :force => true do |t|
-    t.string   "name"
-    t.datetime "created_at", :null => false
-    t.datetime "updated_at", :null => false
-  end
-
   create_table "large_text_fields", :force => true do |t|
     t.string  "field_name",                     :null => false
     t.text    "value",      :limit => 16777215

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -45,7 +45,16 @@ class PassportTest < ActiveSupport::TestCase
       assert_equal true, passport.stamps[0]
       assert_equal false, passport.stamps[5]
       assert_equal nil, passport.stamps[4]
+    end
 
+    should "be able to save and restore empty bitfields" do
+      passport = sample_passport
+
+      passport.save!
+      passport = Passport.find(passport.id)
+
+      passport.stamps[0] = true
+      assert_equal true, passport.stamps[0]
     end
 
     should "not write default values" do

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -32,5 +32,20 @@ class PassportTest < ActiveSupport::TestCase
 
       assert_equal %w(Canada Mexico), passport.foreign_visits.map(&:country)
     end
+
+    should "be able to access bitfields" do
+      passport = sample_passport
+
+      passport.stamps[0] = true
+      passport.stamps[5] = false
+
+      passport.save!
+      passport = Passport.find(passport.id)
+
+      assert_equal true, passport.stamps[0]
+      assert_equal false, passport.stamps[5]
+      assert_equal nil, passport.stamps[4]
+
+    end
   end
 end

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -47,5 +47,25 @@ class PassportTest < ActiveSupport::TestCase
       assert_equal nil, passport.stamps[4]
 
     end
+
+    should "not write default values" do
+      passport = sample_passport
+
+      passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+
+      passport.save!
+
+      expected =
+        {
+          "birthdate"=>"Thu, 11 Aug 2011 07:00:00 -0000",
+          "city"=>"Santa Barbara",
+          "foreign_visits"=>[{"country"=>"Canada"},{"country"=>"Mexico"}],
+          "gender"=>"female",
+          "state"=>"California"
+        }
+
+      assert_equal expected, passport.to_store
+
+    end
   end
 end

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -70,11 +70,16 @@ class PassportTest < ActiveSupport::TestCase
           "city"=>"Santa Barbara",
           "foreign_visits"=>[{"country"=>"Canada"},{"country"=>"Mexico"}],
           "gender"=>"female",
-          "state"=>"California"
+          "stamps" => nil,
+          "state"=>"California",
+          "weight" => "100"
         }
 
       assert_equal expected, passport.to_store
 
+      # Should re-assert the defaults when loaded.
+      passport = Passport.find(passport.id)
+      assert_equal 100, passport.weight
     end
   end
 end

--- a/test/dummy/test/unit/travel_itinerary_test.rb
+++ b/test/dummy/test/unit/travel_itinerary_test.rb
@@ -10,7 +10,7 @@ class TravelItineraryTest < ActiveSupport::TestCase
 
       itinerary = TravelItinerary.find(itinerary.id)
       assert_equal ['Spain', 'Ireland'], itinerary.foreign_visits.map(&:country)
-      expected_json_data = '{"estimated_cost":"9001.1","foreign_visits":[{"country":"Spain","visited_at":null},{"country":"Ireland","visited_at":null}]}'
+      expected_json_data = '{"estimated_cost":"9001.1","foreign_visits":[{"country":"Spain"},{"country":"Ireland"}]}'
       assert_equal itinerary.aggregate_field, expected_json_data
       assert_equal '', itinerary.aggregate_store
     end

--- a/test/unit/attribute/bitfield_test.rb
+++ b/test/unit/attribute/bitfield_test.rb
@@ -16,4 +16,16 @@ class Aggregate::Attribute::BitfieldTest < ActiveSupport::TestCase
     assert_equal "tf t",    ad.to_store(Aggregate::Bitfield.limit(4).new("tf t"))
   end
 
+  should "provide a default" do
+    ad = Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4)
+
+    assert_equal Aggregate::Bitfield.limit(4).new(""), ad.default
+
+  end
+
+  should "be valid" do
+    ad = Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4)
+    assert_equal [], ad.validation_errors("")
+  end
+
 end

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -381,17 +381,11 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "ship_from" => {
                     "zip"          => "93101",
                     "address_two"  => "",
-                    "phone_number" => nil,
                     "address_one"  => "1812 Clearview Road",
                     "full_name"    => "Lisa Smith"
                 },
                 "tracking_number"    => "1245",
-                "weight_in_ounces"   => 5,
-                "shipping_method"    => nil,
-                "signature_required" => nil,
-                "shipped_at"         => nil,
-                "postage_due"        => nil,
-                "ship_to"            => nil
+                "weight_in_ounces"   => 5
             }
         }
         assert_equal expected, @doc.to_store
@@ -426,17 +420,11 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "ship_from" => {
                     "zip"          => "93101",
                     "address_two"  => "",
-                    "phone_number" => nil,
                     "address_one"  => "1812 Clearview Road",
                     "full_name"    => "Lisa Smith"
                 },
                 "tracking_number"    => "1245",
-                "weight_in_ounces"   => 5,
-                "shipping_method"    => nil,
-                "signature_required" => nil,
-                "shipped_at"         => nil,
-                "postage_due"        => nil,
-                "ship_to"            => nil
+                "weight_in_ounces"   => 5
             }
         }
         assert_equal expected, @doc.to_store
@@ -505,17 +493,12 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "ship_from" => {
                     "zip"          => "93101",
                     "address_two"  => "",
-                    "phone_number" => nil,
                     "address_one"  => "1812 Clearview Road",
                     "full_name"    => "Lisa Smith"
                 },
                 "tracking_number"    => "1245",
                 "weight_in_ounces"   => 5,
-                "shipping_method"    => "UPS",
-                "postage_due"        => nil,
-                "signature_required" => nil,
-                "shipped_at"         => nil,
-                "ship_to"            => nil
+                "shipping_method"    => "UPS"
             }
           }
           assert_equal expected, @doc.to_store
@@ -573,17 +556,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "ship_from" => {
                     "zip" => "93101",
                     "address_two" => "",
-                    "phone_number" => nil,
                     "address_one" => "1812 Clearview Road",
                     "full_name" => "Lisa Smith"
                 },
                 "tracking_number" => "1245",
                 "weight_in_ounces" => 5,
                 "shipping_method" => "UsPostal",
-                "postage_due" => nil,
                 "signature_required" => true,
-                "shipped_at" => nil,
-                "ship_to" => nil
             }
           }
           assert_equal expected, @doc.to_store
@@ -682,7 +661,6 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "ship_from" => {
                     "zip" => "93101",
                     "address_two" => "",
-                    "phone_number" => nil,
                     "address_one" => "1812 Clearview Road",
                     "full_name" => "Lisa Smith"
                 },
@@ -690,9 +668,6 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
                 "weight_in_ounces" => 5,
                 "shipping_method" => "UsPostal",
                 "postage_due" => '50.2',
-                "signature_required" => nil,
-                "shipped_at" => nil,
-                "ship_to" => nil
             }
           }
           assert_equal expected, @doc.to_store


### PR DESCRIPTION
@c-simmons - Hey Chad - Can I get a quick review of this?  

This changes aggregate to not write nil values to json if there are no migrations on the field.  With customer data, where there are 160 fields, this is a big savings.  Also this fixes a bug I ran into with bitfield.

I have a branch of web that has this integration and it has a green build.

Thanks