### PR TITLE
cdk/domain_name_and_region Update large_text_field to 0.0.2 (f83b33f)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gemspec
 gem "jquery-rails"
 
 gem 'hobo_support',          '2.0.1',    git: 'git@github.com:Invoca/hobosupport'
-gem 'large_text_field',      '0.0.2',    git: 'git@github.com:Invoca/large_text_field.git', ref: '344f89c3a550daebd2513bf3f1d5b1d826d7d9bc'
+gem 'large_text_field',      '0.0.2',  git: 'git@github.com:Invoca/large_text_field.git',      ref: 'f83b33f2c68854b70c41b81d8ac7b7e307bc4312'
 
 group :test do
   gem 'test-unit', '3.1.3'

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "rails",            "~> 3.2.22"
   s.add_dependency "hobo_support",     "2.0.1"
-  s.add_dependency "large_text_field", "0.0.2"
+  s.add_dependency 'large_text_field', '0.0.2'
 
   s.add_development_dependency "invoca-utils", "0.0.2"
   s.add_development_dependency "sqlite3"


### PR DESCRIPTION
@ColinDKelley - This update was generated by invoca_gem because of the version bump for large_text_field.