### PR TITLE
add as_json and to_hash methods to aggregate base

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -17,7 +17,7 @@ GIT
 PATH
   remote: .
   specs:
-    aggregate (0.0.4)
+    aggregate (0.0.5)
       hobo_support (= 2.0.1)
       large_text_field (= 0.0.2)
       rails (~> 3.2.22)
@@ -155,3 +155,6 @@ DEPENDENCIES
   shoulda (= 3.5.0)
   sqlite3
   test-unit (= 3.1.3)
+
+BUNDLED WITH
+   1.12.5

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -41,13 +41,10 @@ module Aggregate
     end
 
     def to_json
-      ActiveSupport::JSON.encode(as_json)
+      ActiveSupport::JSON.encode(to_store)
     end
 
-    def as_json
-      to_store
-    end
-    alias_method :to_hash, :as_json
+    alias_method :to_hash, :to_store
 
     def self.attribute(*args)
       aggregate_attribute(*args)

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -41,8 +41,13 @@ module Aggregate
     end
 
     def to_json
-      ActiveSupport::JSON.encode(to_store)
+      ActiveSupport::JSON.encode(as_json)
     end
+
+    def as_json
+      to_store
+    end
+    alias_method :to_hash, :as_json
 
     def self.attribute(*args)
       aggregate_attribute(*args)

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,3 +1,3 @@
 module Aggregate
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -58,6 +58,14 @@ class Aggregate::BaseTest < ActiveSupport::TestCase
         expected_json_string = ActiveSupport::JSON.encode(@decoded_aggregate_store)
         assert_equal expected_json_string, test_instance.to_json
       end
+
+      should "generate a string with all the attributes after just being built from json and is in an array" do
+        @instance = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
+        test_instance = [@agg.from_json(@instance.to_json)]
+
+        expected_json_string = ActiveSupport::JSON.encode([@decoded_aggregate_store])
+        assert_equal expected_json_string, test_instance.to_json
+      end
     end
 
     context "from_json" do

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -50,6 +50,14 @@ class Aggregate::BaseTest < ActiveSupport::TestCase
         expected_json_string = ActiveSupport::JSON.encode(@decoded_aggregate_store)
         assert_equal expected_json_string, @instance.to_json
       end
+
+      should "generate a string with all the attributes after just being built from json" do
+        @instance = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
+        test_instance = @agg.from_json(@instance.to_json)
+
+        expected_json_string = ActiveSupport::JSON.encode(@decoded_aggregate_store)
+        assert_equal expected_json_string, test_instance.to_json
+      end
     end
 
     context "from_json" do


### PR DESCRIPTION
@mikeweaver @primiti @aschreifels 

Getting this code review up early so that I can get this into web to alleviate any issues around Aggregate classes instituting their own `to_hash` methods like DemographicResult does. 