### PR TITLE
STORY-5105 - allow aggregates to work with Single Table Inheritance

### DIFF
--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -45,7 +45,12 @@ module Aggregate
       end
 
       def aggregated_attributes
-        @aggregated_attributes ||= []
+        @aggregated_attributes ||=
+            if superclass.respond_to?(:aggregated_attributes)
+              superclass.aggregated_attributes.dup
+            else
+              []
+            end
       end
     end
 

--- a/test/dummy/app/models/government_travel_itinerary.rb
+++ b/test/dummy/app/models/government_travel_itinerary.rb
@@ -1,0 +1,5 @@
+class GovernmentTravelItinerary < TravelItinerary
+  attr_accessible :foreign_service_approval
+
+  aggregate_attribute :foreign_service_approval, :string
+end

--- a/test/dummy/db/migrate/20160316211434_create_travel_itineraries.rb
+++ b/test/dummy/db/migrate/20160316211434_create_travel_itineraries.rb
@@ -1,6 +1,7 @@
 class CreateTravelItineraries < ActiveRecord::Migration
   def change
     create_table :travel_itineraries do |t|
+      t.string :type, default: nil
       t.text :aggregate_field
 
       t.timestamps

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -29,6 +29,7 @@ ActiveRecord::Schema.define(version: 20160316211434) do
   end
 
   create_table "travel_itineraries", force: :cascade do |t|
+    t.string   "type"
     t.text     "aggregate_field"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/dummy/test/unit/government_travel_iternary_test.rb
+++ b/test/dummy/test/unit/government_travel_iternary_test.rb
@@ -1,0 +1,20 @@
+require_relative '../../../test_helper'
+
+class GovernmentTravelItineraryTest < ActiveSupport::TestCase
+  context 'initialization' do
+    should 'be able to construct a polymorphic class with aggregates defined at multiple levels' do
+      itinerary = GovernmentTravelItinerary.create!(estimated_cost: 9001.10, foreign_service_approval: "NSA")
+      itinerary.foreign_visits = [ForeignVisit.new(country: 'Spain'), ForeignVisit.new(country: 'Ireland')]
+      itinerary.save!
+
+      itinerary = TravelItinerary.find(itinerary.id)
+      assert itinerary.is_a?(GovernmentTravelItinerary)
+
+      assert_equal "NSA", itinerary.foreign_service_approval
+      assert_equal ['Spain', 'Ireland'], itinerary.foreign_visits.map(&:country)
+      expected_json_data = '{"estimated_cost":"9001.1","foreign_visits":[{"country":"Spain"},{"country":"Ireland"}],"foreign_service_approval":"NSA"}'
+      assert_equal itinerary.aggregate_field, expected_json_data
+      assert_equal '', itinerary.aggregate_store
+    end
+  end
+end


### PR DESCRIPTION
@jacobdanielferguson - I ran into this issue when defining aggregates at different levels of the BulkOperation hierarchy.  Basically, when you define an aggregate to a derived class the aggregates defined in parent classes are not saved or loaded anymore.  The reason is that the class `@variable`  is overwritten and lost.   The fix was easy - when initializing the aggregate attributes for a class, check if the super class has them. If it does, dup them.

The rest is adding an STI test case to the dummy to prove this worked. 

Thanks