### PR TITLE
WEB-3718 unable to update margin: non-comparable values should not be…

### DIFF
--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -28,7 +28,15 @@ module Aggregate
       self.class.aggregated_attribute_handlers.map_and_find do |_, attr|
         return nil unless other.respond_to?(attr.name)
 
-        compare(send(attr.name), other.send(attr.name))._?.nonzero?
+        compare_result = compare(send(attr.name), other.send(attr.name))
+
+        # If compare_result is nil, that means the two values were not comparable (for example, one is a string and one is a float).
+        # We want to stop the comparison and return nil here to signal to the caller that they are not comparable.
+        if compare_result.nil?
+          return compare_result
+        end
+
+        compare_result.nonzero?
       end || 0
     end
 

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -139,7 +139,7 @@ class Aggregate::BaseTest < ActiveSupport::TestCase
       end
 
       should "support comparison for nested instances" do
-        @outer_agg = Class.new(Aggregate::Base) {}
+        @outer_agg = Class.new(Aggregate::Base) { }
         @outer_agg.attribute(:address1, @agg.name)
         @outer_agg.attribute(:address2, @agg.name)
         @outer_agg.attribute(:type, "enum")
@@ -176,7 +176,7 @@ class Aggregate::BaseTest < ActiveSupport::TestCase
       end
 
       should "report non-comparable types as not equal" do
-        agg = Class.new(Aggregate::Base) {}
+        agg = Class.new(Aggregate::Base) { }
         agg.attribute(:testme, :float)
 
         agg_with_string = agg.new(testme: "1234")

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -127,51 +127,63 @@ class Aggregate::BaseTest < ActiveSupport::TestCase
       assert_nil @agg.new.respond_to_without_attributes?("could", "be", "anything")
     end
 
-    should "provide comparable methods for instances" do
-      @first  = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
-      @same   = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
-      @second = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_102)
+    context "comparisons" do
+      should "provide comparable methods for instances" do
+        @first  = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
+        @same   = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101)
+        @second = @agg.new(name: "Bob", address: "1812 clearview", zip: 93_102)
 
-      assert @first == @same
-      assert @first != @second
-      assert @first < @second
-    end
+        assert @first == @same
+        assert @first != @second
+        assert @first < @second
+      end
 
-    should "support comparison for nested instances" do
-      @outer_agg = Class.new(Aggregate::Base) {}
-      @outer_agg.attribute(:address1, @agg.name)
-      @outer_agg.attribute(:address2, @agg.name)
-      @outer_agg.attribute(:type, "enum")
-      @outer_agg.attribute(:istrue, "boolean")
+      should "support comparison for nested instances" do
+        @outer_agg = Class.new(Aggregate::Base) {}
+        @outer_agg.attribute(:address1, @agg.name)
+        @outer_agg.attribute(:address2, @agg.name)
+        @outer_agg.attribute(:type, "enum")
+        @outer_agg.attribute(:istrue, "boolean")
 
-      @first = @outer_agg.new(
-        type: :tiger,
-        istrue: false,
-        address1: @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101),
-        address2: @agg.new(name: "Murphy", address: "1414 mountain", zip: 93_103)
-      )
+        @first = @outer_agg.new(
+          type: :tiger,
+          istrue: false,
+          address1: @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101),
+          address2: @agg.new(name: "Murphy", address: "1414 mountain", zip: 93_103)
+        )
 
-      @second = @outer_agg.new(
-        type: :tiger,
-        istrue: false,
-        address1: @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101),
-        address2: @agg.new(name: "Murphy", address: "1414 mountain", zip: 93_103)
-      )
+        @second = @outer_agg.new(
+          type: :tiger,
+          istrue: false,
+          address1: @agg.new(name: "Bob", address: "1812 clearview", zip: 93_101),
+          address2: @agg.new(name: "Murphy", address: "1414 mountain", zip: 93_103)
+        )
 
-      assert @first == @second
-      @second.address2.zip = 93_102
-      assert @first != @second
-      assert @first > @second
+        assert @first == @second
+        @second.address2.zip = 93_102
+        assert @first != @second
+        assert @first > @second
 
-      @second.address2.zip = 93_103
-      assert @first == @second
+        @second.address2.zip = 93_103
+        assert @first == @second
 
-      @first.type = nil
-      assert @first != @second
-      assert @first > @second
+        @first.type = nil
+        assert @first != @second
+        assert @first > @second
 
-      @second.type = nil
-      assert @first == @second
+        @second.type = nil
+        assert @first == @second
+      end
+
+      should "report non-comparable types as not equal" do
+        agg = Class.new(Aggregate::Base) {}
+        agg.attribute(:testme, :float)
+
+        agg_with_string = agg.new(testme: "1234")
+        agg_with_float  = agg.new(testme: 1234)
+
+        assert agg_with_string != agg_with_float
+      end
     end
 
     context "has_many associations" do


### PR DESCRIPTION
… equal

When comparing uncomparable items (such as a string and a float), our spaceship operator method was incorrectly returning 0, which meant the two items were equal. Updated this to instead return nil if the two items cannot be compared.

Ticket: https://ringrevenue.atlassian.net/browse/WEB-3718
Web PR: https://github.com/Invoca/web/pull/8306