### PR TITLE
TECH-2930 require rails: fix dependencies

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "jquery-rails"
 
 gem 'encryptor',            '3.0.0'
 gem 'hobo_support',         '2.0.1',  git: 'git@github.com:Invoca/hobosupport',           ref: 'b9086322274b474a2b5bae507c4885e55d4aa050'
-gem 'large_text_field',     '0.0.2',  git: 'git@github.com:Invoca/large_text_field.git',  ref: 'f24f25aa4641ba33c3b5e8698be23cc62d2cdea8'
+gem 'large_text_field',     '0.0.2',  git: 'git@github.com:Invoca/large_text_field.git',  ref: 'ab98c90061fe63d5829f6be9d4386c21638b87bc'
 gem 'protected_attributes', '1.1.3'
 
 group :test do

--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,7 @@ gem "jquery-rails"
 
 gem 'encryptor',            '3.0.0'
 gem 'hobo_support',         '2.0.1',  git: 'git@github.com:Invoca/hobosupport',           ref: 'b9086322274b474a2b5bae507c4885e55d4aa050'
-gem 'large_text_field',     '0.0.2',  git: 'git@github.com:Invoca/large_text_field.git',  ref: 'ab98c90061fe63d5829f6be9d4386c21638b87bc'
+gem 'large_text_field',               git: 'git@github.com:Invoca/large_text_field.git',  ref: '2efc950395352bf8b7f45891122f6bc42b171526'
 gem 'protected_attributes', '1.1.3'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,8 +8,8 @@ GIT
 
 GIT
   remote: git@github.com:Invoca/large_text_field.git
-  revision: f24f25aa4641ba33c3b5e8698be23cc62d2cdea8
-  ref: f24f25aa4641ba33c3b5e8698be23cc62d2cdea8
+  revision: ab98c90061fe63d5829f6be9d4386c21638b87bc
+  ref: ab98c90061fe63d5829f6be9d4386c21638b87bc
   specs:
     large_text_field (0.0.2)
       hobo_support (= 2.0.1)
@@ -24,7 +24,6 @@ PATH
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
       large_text_field (= 0.0.2)
-      rails (~> 4.0)
 
 GEM
   remote: https://rubygems.org/

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -24,7 +24,6 @@ PATH
       hobo_support (= 2.0.1)
       large_text_field (= 0.0.2)
       rails (~> 4.0)
-      railties (~> 4.0)
 
 GEM
   remote: https://rubygems.org/
@@ -183,4 +182,4 @@ DEPENDENCIES
   test-unit (= 3.1.3)
 
 BUNDLED WITH
-   1.16.1
+   1.16.5

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,7 @@ PATH
   remote: .
   specs:
     aggregate (0.0.5)
+      activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
       large_text_field (= 0.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,13 +8,13 @@ GIT
 
 GIT
   remote: git@github.com:Invoca/large_text_field.git
-  revision: ab98c90061fe63d5829f6be9d4386c21638b87bc
-  ref: ab98c90061fe63d5829f6be9d4386c21638b87bc
+  revision: 2efc950395352bf8b7f45891122f6bc42b171526
+  ref: 2efc950395352bf8b7f45891122f6bc42b171526
   specs:
-    large_text_field (0.0.2)
+    large_text_field (0.2.0)
       hobo_support (= 2.0.1)
       protected_attributes
-      rails (~> 4.2.10)
+      rails (~> 4.2)
 
 PATH
   remote: .
@@ -23,7 +23,7 @@ PATH
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
-      large_text_field (= 0.0.2)
+      large_text_field (~> 0.2)
 
 GEM
   remote: https://rubygems.org/
@@ -171,7 +171,7 @@ DEPENDENCIES
   hobo_support (= 2.0.1)!
   invoca-utils (= 0.0.2)
   jquery-rails
-  large_text_field (= 0.0.2)!
+  large_text_field!
   minitest (~> 5.1)
   protected_attributes (= 1.1.3)
   pry

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -18,10 +18,11 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
+  s.add_dependency "activerecord",     "~> 4.0"
   s.add_dependency "encryptor",        "~> 3.0"
   s.add_dependency "hobo_support",     "2.0.1"
   s.add_dependency "large_text_field", "0.0.2"
-  s.add_dependency "rails",         "~> 4.0"
+  s.add_dependency "rails",            "~> 4.0"
 
   s.add_development_dependency "invoca-utils", "0.0.2"
   s.add_development_dependency "sqlite3"

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.push File.expand_path('lib', __dir__)
+$LOAD_PATH.push File.expand_path("lib", __dir__)
 
 # Maintain your gem's version:
 require "aggregate/version"
@@ -20,9 +20,8 @@ Gem::Specification.new do |s|
 
   s.add_dependency "encryptor",        "~> 3.0"
   s.add_dependency "hobo_support",     "2.0.1"
-  s.add_dependency 'large_text_field', '0.0.2'
-  s.add_dependency "rails",            "~> 4.0"
-  s.add_dependency "railties",            "~> 4.0"
+  s.add_dependency "large_text_field", "0.0.2"
+  s.add_dependency "rails",         "~> 4.0"
 
   s.add_development_dependency "invoca-utils", "0.0.2"
   s.add_development_dependency "sqlite3"

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -22,7 +22,6 @@ Gem::Specification.new do |s|
   s.add_dependency "encryptor",        "~> 3.0"
   s.add_dependency "hobo_support",     "2.0.1"
   s.add_dependency "large_text_field", "0.0.2"
-  s.add_dependency "rails",            "~> 4.0"
 
   s.add_development_dependency "invoca-utils", "0.0.2"
   s.add_development_dependency "sqlite3"

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -21,5 +21,5 @@ Gem::Specification.new do |s|
   s.add_dependency "activerecord",     "~> 4.0"
   s.add_dependency "encryptor",        "~> 3.0"
   s.add_dependency "hobo_support",     "2.0.1"
-  s.add_dependency "large_text_field", "0.0.2"
+  s.add_dependency "large_text_field", "~> 0.2"
 end

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "rails"
+require "active_record"
 
 require "aggregate/bitfield"
 

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require "rails"
+
 require "aggregate/bitfield"
 
 require "aggregate/attribute/base"

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require "rails"
 require "active_record"
 
 require "aggregate/bitfield"
@@ -21,7 +20,6 @@ require "aggregate/attribute/list"
 require "aggregate/attribute/bitfield"
 require "aggregate/attribute/hash"
 
-require "aggregate/engine"
 require "aggregate/aggregate_store"
 require "aggregate/attribute_handler"
 require "aggregate/base"

--- a/lib/aggregate/engine.rb
+++ b/lib/aggregate/engine.rb
@@ -1,7 +1,0 @@
-# frozen_string_literal: true
-
-module Aggregate
-  class Engine < ::Rails::Engine
-    isolate_namespace Aggregate
-  end
-end

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,5 +1,4 @@
 # frozen_string_literal: true
 
 Rails.application.routes.draw do
-  mount Aggregate::Engine => "/aggregate"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,6 +3,8 @@
 # Configure Rails Environment
 ENV["RAILS_ENV"] = "test"
 
+require "aggregate"
+
 require File.expand_path('dummy/config/environment.rb', __dir__)
 require "rails/test_help"
 require "invoca/utils"


### PR DESCRIPTION
- drop dependency on railties
- require railts

Without the explicit `require`, we're getting lucky that every time `aggregate` is pulled in _something_ pulled in `rails` first. 
