### PR TITLE
TECH-2969 - allow aggregates to be defined without requiring large text field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog 
+All notable changes to this project will be documented in this file. 
+## [1.0.0] - 2019-01-15 
+### Changed 
+- Require `store_aggregates_using` or `store_aggregates_using_large_text_field` usage when using `Aggregate::Container` in order to move away from writing to `large_text_fields`. This is not backwards compatible as all classes using `Aggregate::Container` will need to be updated. 
+## [0.2.0] - 2019-01-14 
+### Added 
+- Added initial entry in ChangeLog (see README at this point for gem details)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    aggregate (0.2.0)
+    aggregate (1.0.0)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)
@@ -182,4 +182,4 @@ DEPENDENCIES
   test-unit (= 3.1.3)
 
 BUNDLED WITH
-   1.16.5
+   1.17.1

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -5,21 +5,30 @@ require 'large_text_field'
 module Aggregate
   module Container
     extend ActiveSupport::Concern
-    include LargeTextField::Owner
     include Aggregate::AggregateStore
+    include ActiveSupport::Callbacks
 
     included do
-      large_text_field :aggregate_store
-      set_callback(:large_text_field_save, :before, :write_aggregates)
       validate :validate_aggregates
       send(:define_callbacks, :aggregate_load)
       send(:define_callbacks, :aggregate_load_schema)
       send(:define_callbacks, :aggregate_load_check_schema)
-      class_attribute :aggregate_container_options
-      self.aggregate_container_options = {
-        use_storage_field: nil,
-        use_large_text_field_as_failover: false
-      }
+      class_attribute :aggregate_storage_field
+      class_attribute :migrate_from_storage_field
+
+      def self.store_aggregates_using_large_text_field
+        include LargeTextField::Owner
+        large_text_field :aggregate_store
+        self.aggregate_storage_field = :aggregate_store
+        self.migrate_from_storage_field = nil
+        set_callback(:large_text_field_save, :before, :write_aggregates)
+      end
+
+      def self.store_aggregates_using(storage_field, migrate_from_storage_field: nil)
+        self.aggregate_storage_field = storage_field
+        self.migrate_from_storage_field = migrate_from_storage_field
+        set_callback(:save, :before, :write_aggregates)
+      end
     end
 
     def aggregate_owner
@@ -47,6 +56,7 @@ module Aggregate
     end
 
     def write_aggregates
+      self.class.aggregate_storage_field or raise "Must call store_aggregates_using or store_aggregates_using_large_text_field"
       if @decoded_aggregate_store_loaded
         encoded_data = if schema_version? || any_non_default_values?
                          ActiveSupport::JSON.encode(to_store)
@@ -54,24 +64,8 @@ module Aggregate
                          ''
                        end
 
-        send("#{aggregate_storage_field}=", encoded_data)
+        send("#{self.class.aggregate_storage_field}=", encoded_data)
       end
-    end
-
-    def uses_aggregate_storage_field?
-      !!self.class.aggregate_container_options[:use_storage_field].presence
-    end
-
-    def aggregate_storage_field
-      if uses_aggregate_storage_field?
-        self.class.aggregate_container_options[:use_storage_field]
-      else
-        :aggregate_store
-      end
-    end
-
-    def failover_to_large_text_field?
-      !!(uses_aggregate_storage_field? && self.class.aggregate_container_options[:use_large_text_field_as_failover])
     end
 
     def reload
@@ -83,10 +77,13 @@ module Aggregate
     private
 
     def aggregate_store_data
-      if (field_data = send(aggregate_storage_field)) && field_data.present?
+      read_store_from_field(self.class.aggregate_storage_field) ||
+        read_store_from_field(self.class.migrate_from_storage_field)
+    end
+
+    def read_store_from_field(field)
+      if field && (field_data = send(field)) && field_data.present?
         field_data
-      elsif failover_to_large_text_field?
-        aggregate_store
       end
     end
   end

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -10,6 +10,7 @@ module Aggregate
 
     class StorageAlreadyDefined < ArgumentError; end
 
+    # rubocop:disable Metrics/BlockLength
     included do
       validate :validate_aggregates
       send(:define_callbacks, :aggregate_load)
@@ -20,8 +21,7 @@ module Aggregate
 
       class << self
         def store_aggregates_using_large_text_field
-          aggregate_storage_field and
-            raise StorageAlreadyDefined, "aggregate_storage_field is already set to #{aggregate_storage_field.inspect}"
+          raise_if_aggregate_storage_field_already_defined
           include LargeTextField::Owner
           large_text_field :aggregate_store
           self.aggregate_storage_field = :aggregate_store
@@ -30,13 +30,22 @@ module Aggregate
         end
 
         def store_aggregates_using(storage_field, migrate_from_storage_field: nil)
-          aggregate_storage_field and raise StorageAlreadyDefined, "aggregate_storage_field is already set to #{aggregate_storage_field.inspect}"
+          raise_if_aggregate_storage_field_already_defined
           self.aggregate_storage_field = storage_field
           self.migrate_from_storage_field = migrate_from_storage_field
           set_callback(:save, :before, :write_aggregates)
         end
+
+        private
+
+        def raise_if_aggregate_storage_field_already_defined
+          if aggregate_storage_field
+            raise StorageAlreadyDefined, "aggregate_storage_field is already set to #{aggregate_storage_field.inspect}"
+          end
+        end
       end
     end
+    # rubocop:enable Metrics/BlockLength
 
     def aggregate_owner
       nil

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -5,8 +5,8 @@ require 'large_text_field'
 module Aggregate
   module Container
     extend ActiveSupport::Concern
-    include Aggregate::AggregateStore
     include ActiveSupport::Callbacks
+    include Aggregate::AggregateStore
 
     class StorageAlreadyDefined < ArgumentError; end
 

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "0.2.0"
+  VERSION = "1.0.0"
 end

--- a/test/dummy/app/models/flight.rb
+++ b/test/dummy/app/models/flight.rb
@@ -6,7 +6,7 @@ class Flight < ActiveRecord::Base
   attr_accessible :flight_number
 
   include Aggregate::Container
-  aggregate_container_options[:use_storage_field] = :aggregate_field
+  store_aggregates_using(:aggregate_field)
 
   aggregate_has_many :passengers, "Passenger"
 end

--- a/test/dummy/app/models/passport.rb
+++ b/test/dummy/app/models/passport.rb
@@ -7,6 +7,7 @@ class Passport < ActiveRecord::Base
   attr_accessible :gender, :city, :state, :birthdate, :height, :weight, :photo, :foreign_visits, :stamps, :password
 
   include Aggregate::Container
+  store_aggregates_using_large_text_field
 
   aggregate_attribute :gender,           :enum, limit: [:male, :female], required: true
   aggregate_attribute :city,             :string,   required: true

--- a/test/dummy/app/models/travel_itinerary.rb
+++ b/test/dummy/app/models/travel_itinerary.rb
@@ -6,7 +6,7 @@ class TravelItinerary < ActiveRecord::Base
   attr_accessible :estimated_cost
 
   include Aggregate::Container
-  aggregate_container_options[:use_storage_field] = :aggregate_field
+  store_aggregates_using :aggregate_field
 
   aggregate_attribute :estimated_cost, :decimal
   aggregate_has_many :foreign_visits, "ForeignVisit"

--- a/test/dummy/test/unit/government_travel_iternary_test.rb
+++ b/test/dummy/test/unit/government_travel_iternary_test.rb
@@ -16,7 +16,6 @@ class GovernmentTravelItineraryTest < ActiveSupport::TestCase
       assert_equal ['Spain', 'Ireland'], itinerary.foreign_visits.map(&:country)
       expected_json_data = '{"estimated_cost":"9001.1","foreign_visits":[{"country":"Spain"},{"country":"Ireland"}],"foreign_service_approval":"NSA"}'
       assert_equal itinerary.aggregate_field, expected_json_data
-      assert_equal '', itinerary.aggregate_store
     end
   end
 end

--- a/test/dummy/test/unit/travel_itinerary_test.rb
+++ b/test/dummy/test/unit/travel_itinerary_test.rb
@@ -5,7 +5,6 @@ require_relative '../../../test_helper'
 class TravelItineraryTest < ActiveSupport::TestCase
   context 'initialization' do
     should 'be able to construct a class with aggregates stored in a field' do
-      assert_equal :aggregate_field, TravelItinerary.aggregate_container_options[:use_storage_field]
       itinerary = TravelItinerary.create!(estimated_cost: 9001.10)
       itinerary.foreign_visits = [ForeignVisit.new(country: 'Spain'), ForeignVisit.new(country: 'Ireland')]
       itinerary.save!
@@ -14,7 +13,6 @@ class TravelItineraryTest < ActiveSupport::TestCase
       assert_equal ['Spain', 'Ireland'], itinerary.foreign_visits.map(&:country)
       expected_json_data = '{"estimated_cost":"9001.1","foreign_visits":[{"country":"Spain"},{"country":"Ireland"}]}'
       assert_equal itinerary.aggregate_field, expected_json_data
-      assert_equal '', itinerary.aggregate_store
     end
   end
 end

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -821,5 +821,33 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       assert_equal true, @doc.instance_variable_get("@reload_called")
       assert_equal "56789", @doc.test_string
     end
+
+    should "raise an exception if attempting to define a class with multiple stores" do
+      assert_raises Aggregate::Container::StorageAlreadyDefined do
+        class MultipleStores < ActiveRecordStub
+          include Aggregate::Container
+
+          store_aggregates_using :storage, migrate_from_storage_field: :old_storage
+          store_aggregates_using_large_text_field
+
+          attr_accessor :storage, :old_storage
+          aggregate_attribute :test_string, :string
+        end
+      end
+    end
+
+    should "raise an exception if attempting to define a class with multiple stores in reverse order" do
+      assert_raises Aggregate::Container::StorageAlreadyDefined do
+        class MultipleStores < ActiveRecordStub
+          include Aggregate::Container
+
+          store_aggregates_using_large_text_field
+          store_aggregates_using :storage, migrate_from_storage_field: :old_storage
+
+          attr_accessor :storage, :old_storage
+          aggregate_attribute :test_string, :string
+        end
+      end
+    end
   end
 end

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -5,6 +5,8 @@ require_relative '../test_helper'
 class Aggregate::ContainerTest < ActiveSupport::TestCase
 
   class ActiveRecordStub
+    include ActiveSupport::Callbacks
+
     # Faking out active record things to get the large text field to work.
     def self.reflections
       {}
@@ -31,6 +33,8 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     def reload
       @reload_called = true
     end
+
+    define_callbacks :save
   end
 
   class TestAddress < Aggregate::Base
@@ -62,6 +66,7 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
   class TestPurchase < ActiveRecordStub
     include Aggregate::Container
+    store_aggregates_using_large_text_field
 
     attr_accessor :fixup1_called, :fixup2_called, :value_at_fixup1, :upgraded_from_schema_version, :value_at_upgrade
 
@@ -87,7 +92,6 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     set_callback(:aggregate_load) do |obj|
       obj.fixup2_called = true
     end
-
     aggregate_schema_version "2.0", :fix_aggregate_schema
 
     def fix_aggregate_schema(current_version)
@@ -103,6 +107,7 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
   class TestPurchaseNoVersion < ActiveRecordStub
     include Aggregate::Container
+    store_aggregates_using_large_text_field
 
     attr_accessor :fixup1_called, :fixup2_called, :value_at_fixup1, :upgraded_from_schema_version, :value_at_upgrade
 
@@ -132,51 +137,51 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     aggregate_attribute :second_shipment, "Aggregate::ContainerTest::TestShippingRecord"
   end
 
+  class TestDirectStore < ActiveRecordStub
+    include Aggregate::Container
+    store_aggregates_using :storage
+
+    attr_accessor :storage
+
+    aggregate_attribute :test_string, :string
+  end
+
+  class TestDirectStoreMigrating < ActiveRecordStub
+    include Aggregate::Container
+    store_aggregates_using :storage, migrate_from_storage_field: :old_storage
+
+    def initialize(storage, old_storage)
+      @storage = storage
+      @old_storage = old_storage
+    end
+
+    attr_accessor :storage, :old_storage
+
+    aggregate_attribute :test_string, :string
+  end
+
   context "sample_data" do
-    setup do
-      @aggregate_container_options = TestPurchase.aggregate_container_options.dup
-    end
-
-    teardown do
-      TestPurchase.aggregate_container_options = @aggregate_container_options
-    end
-
     context "initialization" do
-      should "have configured the active record settings correctly" do
-        # Configure a large text field.
+      should "should create a large text field and configure it as a store with the right callback when using large text fields" do
         assert_equal [[:large_text_fields, { inverse_of: :owner, as: :owner, dependent: :destroy, autosave: true, class_name: "LargeTextField::NamedTextValue" }]], TestPurchase.instance_eval('@has_many_args', __FILE__, __LINE__)
-        assert_equal [[:validate_large_text_fields], [:validate_aggregates]], TestPurchase.instance_eval('@validate_args', __FILE__, __LINE__)
+        assert_equal [[:validate_aggregates], [:validate_large_text_fields]], TestPurchase.instance_eval('@validate_args', __FILE__, __LINE__)
         assert_equal [[:write_large_text_field_changes]], TestPurchase.instance_eval('@before_save', __FILE__, __LINE__)
+        assert_equal :aggregate_store, TestPurchase.aggregate_storage_field
+        assert_nil TestPurchase.migrate_from_storage_field
       end
 
-      should "have a configuration with defaults" do
-        assert_nil TestPurchase.aggregate_container_options[:use_storage_field]
-        assert_false TestPurchase.aggregate_container_options[:use_large_text_field_as_failover]
+      should "not configure a large text field when using storage" do
+        assert_nil TestDirectStore.instance_eval('@has_many_args', __FILE__, __LINE__)
+        assert_equal [[:validate_aggregates]], TestDirectStore.instance_eval('@validate_args', __FILE__, __LINE__)
+        assert_equal :storage, TestDirectStore.aggregate_storage_field
+        assert_nil TestDirectStore.migrate_from_storage_field
       end
 
-      should "know when using a storage field or a large text field" do
-        assert_false TestPurchase.new.uses_aggregate_storage_field?
-        TestPurchase.aggregate_container_options[:use_storage_field] = :aggregate_field_store
-        assert TestPurchase.new.uses_aggregate_storage_field?
-      end
-
-      should "know which field the aggregate data is stored in" do
-        assert_equal :aggregate_store, TestPurchase.new.aggregate_storage_field
-        TestPurchase.aggregate_container_options[:use_storage_field] = :aggregate_field_store
-        assert_equal :aggregate_field_store, TestPurchase.new.aggregate_storage_field
-      end
-
-      should "know when to failover to large_text_field" do
-        assert_false TestPurchase.new.failover_to_large_text_field?
-
-        TestPurchase.aggregate_container_options[:use_storage_field] = :aggregate_field_store
-        assert_false TestPurchase.new.failover_to_large_text_field?
-
-        TestPurchase.aggregate_container_options[:use_large_text_field_as_failover] = true
-        assert TestPurchase.new.failover_to_large_text_field?
-
-        TestPurchase.aggregate_container_options[:use_storage_field] = nil
-        assert_false TestPurchase.new.failover_to_large_text_field?
+      should "allow storage to be migrated from one field to another" do
+        assert_nil TestDirectStoreMigrating.instance_eval('@has_many_args', __FILE__, __LINE__)
+        assert_equal [[:validate_aggregates]], TestDirectStoreMigrating.instance_eval('@validate_args', __FILE__, __LINE__)
+        assert_equal :storage, TestDirectStoreMigrating.aggregate_storage_field
+        assert_equal :old_storage,  TestDirectStoreMigrating.migrate_from_storage_field
       end
     end
 
@@ -285,58 +290,19 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       end
     end
 
-    context "loading" do
+    context "reading from storage" do
       setup do
-        @json = {
-          'first_shipment' => {
-            'tracking_number'  => '1245',
-            'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
-              'address_one' => '1812 Clearview Road',
-              'address_two' => '',
-              'zip'         => '93101'
-            }
-          }
-        }.to_json
+        @json = { 'test_string' => 'found_it' }.to_json
       end
 
-      should "load from the large_text_field when no storage_field is specified" do
-        @doc = TestPurchase.new(@json, nil)
-        assert_false @doc.uses_aggregate_storage_field?
-        assert_nil @doc.aggregate_field_store
-        assert_equal @json, @doc.aggregate_store
-
-        assert_equal '1245', @doc.first_shipment.tracking_number
-        assert_equal 5, @doc.first_shipment.weight_in_ounces
-        assert_equal 'Lisa Smith', @doc.first_shipment.ship_from.full_name
+      should "load from initial field when present" do
+        @doc = TestDirectStoreMigrating.new(@json, '')
+        assert_equal 'found_it', @doc.test_string
       end
 
-      should "load from the storage_field when it's specified" do
-        assert_nil TestPurchase.aggregate_container_options[:use_storage_field]
-        TestPurchase.aggregate_container_options[:use_storage_field] = :aggregate_field_store
-        @doc                                                         = TestPurchase.new(nil, @json)
-        assert @doc.uses_aggregate_storage_field?
-        assert_nil @doc.aggregate_store
-        assert_equal @json, @doc.aggregate_field_store
-
-        assert_equal 5, @doc.first_shipment.weight_in_ounces
-        assert_equal 'Lisa Smith', @doc.first_shipment.ship_from.full_name
-      end
-
-      should "load from the large_text_field when storage_field and failover are enabled but storage_field is blank" do
-        assert_nil TestPurchase.aggregate_container_options[:use_storage_field]
-        assert_false TestPurchase.aggregate_container_options[:use_large_text_field_as_failover]
-        TestPurchase.aggregate_container_options[:use_storage_field]                = :aggregate_field_store
-        TestPurchase.aggregate_container_options[:use_large_text_field_as_failover] = true
-
-        @doc = TestPurchase.new(@json, nil)
-        assert @doc.uses_aggregate_storage_field?
-        assert @doc.failover_to_large_text_field?
-        assert_nil @doc.aggregate_field_store
-        assert_equal @json, @doc.aggregate_store
-
-        assert_equal 'Lisa Smith', @doc.first_shipment.ship_from.full_name
+      should "load from the migrating field when the store is not present" do
+        @doc = TestDirectStoreMigrating.new('', @json)
+        assert_equal 'found_it', @doc.test_string
       end
     end
 
@@ -405,44 +371,6 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
         @doc.write_aggregates
         assert_equal expected, ActiveSupport::JSON.decode(@doc.aggregate_store)
-      end
-
-      should "use an alternative field for storage if specified by the config" do
-        json = {
-          'first_shipment' => {
-            'tracking_number'  => '1245',
-            'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
-              'address_one' => '1812 Clearview Road',
-              'address_two' => '',
-              'zip'         => '93101'
-            }
-          }
-        }.to_json
-        assert_nil TestPurchase.aggregate_container_options[:use_storage_field]
-        TestPurchase.aggregate_container_options[:use_storage_field] = :aggregate_field_store
-        @doc                                                         = TestPurchase.new(nil, json)
-        assert_nil @doc.aggregate_store
-
-        expected = {
-          "data_schema_version" => "2.0",
-          "test_string"         => nil,
-          "second_shipment"     => nil,
-          "first_shipment"      => {
-            "ship_from" => {
-              "zip"         => "93101",
-              "address_two" => "",
-              "address_one" => "1812 Clearview Road",
-              "full_name"   => "Lisa Smith"
-            },
-            "tracking_number"  => "1245",
-            "weight_in_ounces" => 5
-          }
-        }
-        assert_equal expected, @doc.to_store
-        @doc.write_aggregates
-        assert_equal expected, ActiveSupport::JSON.decode(@doc.aggregate_field_store)
       end
 
       should "write an empty string for classes at default values" do


### PR DESCRIPTION
This makes a minor interface change to large text field.   Remove the aggregate container options in favor of declarative methods that describe where the aggregate data can be saved.    All classes that include Aggregate::Container need to also call either `store_aggregates_using_large_text_field` or `store_aggregates_using :<my_storage_field>`.    The latter method takes an optional `migrate_from_storage_field:` argument that can be used to migrate storage from one field to another.  (This is what we use when we start removing large text field support form a model.)

We need to follow this pull request with a change to the definition of every aggregate to set the appropriate option.