### PR TITLE
TECH-3165 - belongs to should not auto-load when just returning the id

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ test/dummy/tmp/
 test/dummy/.sass-cache
 .idea
 .rubocop-http*
+.DS_Store

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    aggregate (0.1.0)
+    aggregate (0.2.0)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -25,6 +25,7 @@ require "aggregate/attribute_handler"
 require "aggregate/base"
 require "aggregate/combined_string_field"
 require "aggregate/container"
+require "aggregate/foreign_key_reference"
 
 module Aggregate
   class << self

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -29,7 +29,7 @@ module Aggregate
         agg_attribute = Aggregate::AttributeHandler.belongs_to_factory("#{name}_id", full_attr_handler_options(options))
         aggregated_attribute_handlers[name] = agg_attribute
 
-        define_method(name)                       { load_aggregate_attribute(agg_attribute) }
+        define_method(name)                       { load_aggregate_attribute(agg_attribute)._?.value }
         define_method("#{name}_id")               { load_aggregate_attribute(agg_attribute)._?.id }
         define_method("#{name}=")                 { |value| save_aggregate_attribute(agg_attribute, value) }
         define_method("#{name}_id=")              { |value| save_aggregate_attribute(agg_attribute, value) }

--- a/lib/aggregate/attribute/foreign_key.rb
+++ b/lib/aggregate/attribute/foreign_key.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 class Aggregate::Attribute::ForeignKey < Aggregate::Attribute::Base
-
   def self.available_options
     super + [
       :class_name # The class for the foreign key
@@ -9,17 +8,15 @@ class Aggregate::Attribute::ForeignKey < Aggregate::Attribute::Base
   end
 
   def from_value(value)
-    if value.is_a?(ActiveRecord::Base)
-      value
-    elsif value.nil?
-      nil
-    else
-      klass.find(value)
+    if value
+      Aggregate::ForeignKeyReference.new(klass, value)
     end
   end
 
   def from_store(value)
-    klass.find(value) if value
+    if value
+      Aggregate::ForeignKeyReference.new(klass, value)
+    end
   end
 
   def to_store(value)

--- a/lib/aggregate/attribute/hash.rb
+++ b/lib/aggregate/attribute/hash.rb
@@ -74,10 +74,8 @@ module Aggregate
       def should_store_hash_as_json
         if options.key?(:store_hash_as_json)
           options[:store_hash_as_json]
-        elsif options.dig(:aggregate_db_storage_type) == :elasticsearch
-          false
         else
-          true
+          options.dig(:aggregate_db_storage_type) != :elasticsearch
         end
       end
     end

--- a/lib/aggregate/foreign_key_reference.rb
+++ b/lib/aggregate/foreign_key_reference.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+class Aggregate::ForeignKeyReference
+  attr_reader :id
+
+  def initialize(klass, id_or_value)
+    @class = klass
+
+    if id_or_value.is_a?(ActiveRecord::Base)
+      @value = id_or_value
+      @id = @value.id
+    else
+      @id = id_or_value.to_i
+    end
+  end
+
+  def value
+    @value ||= @class.find(@id)
+  end
+end

--- a/test/dummy/app/models/flight.rb
+++ b/test/dummy/app/models/flight.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+class Flight < ActiveRecord::Base
+  attr_accessible :aggregate_field, :passengers
+
+  attr_accessible :flight_number
+
+  include Aggregate::Container
+  aggregate_container_options[:use_storage_field] = :aggregate_field
+
+  aggregate_has_many :passengers, "Passenger"
+end

--- a/test/dummy/app/models/passenger.rb
+++ b/test/dummy/app/models/passenger.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Passenger < Aggregate::Base
+  attribute :name,    :string
+  belongs_to :passport, class_name: "Passport"
+end

--- a/test/dummy/app/models/passport.rb
+++ b/test/dummy/app/models/passport.rb
@@ -19,4 +19,11 @@ class Passport < ActiveRecord::Base
   aggregate_attribute :stamps,           :bitfield, limit: 10
   aggregate_attribute :password,         :string,   encrypted: true
 
+  # Test help
+  cattr_accessor :initialization_count
+
+  after_initialize do
+    self.class.initialization_count ||= 0
+    self.class.initialization_count += 1
+  end
 end

--- a/test/dummy/db/migrate/20180204000000_create_flights.rb
+++ b/test/dummy/db/migrate/20180204000000_create_flights.rb
@@ -1,0 +1,10 @@
+class CreateFlights < ActiveRecord::Migration
+  def change
+    create_table :flights do |t|
+      t.string :flight_number, default: nil
+      t.text :aggregate_field
+
+      t.timestamps
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160316211434) do
+ActiveRecord::Schema.define(version: 20180204000000) do
+
+  create_table "flights", force: :cascade do |t|
+    t.string   "flight_number"
+    t.text     "aggregate_field"
+    t.datetime "created_at"
+    t.datetime "updated_at"
+  end
 
   create_table "large_text_fields", force: :cascade do |t|
     t.string  "field_name",                  null: false

--- a/test/unit/attribute/date_time_test.rb
+++ b/test/unit/attribute/date_time_test.rb
@@ -18,7 +18,7 @@ class Aggregate::Attribute::DateTimeTest < ActiveSupport::TestCase
 
   should "handle parsing and storing datetime based on aggregate_db_storage_type option being :elasticsearch" do
     ad   = Aggregate::AttributeHandler.factory("testme", :datetime, aggregate_db_storage_type: :elasticsearch)
-    time = Time.at(1544732833).in_time_zone("Pacific Time (US & Canada)")
+    time = Time.at(1_544_732_833).in_time_zone("Pacific Time (US & Canada)")
 
     assert_equal "12/13/18   8:27 PM", ad.from_value(time.iso8601).utc.to_s
     assert_equal "2018-12-13T20:27:13Z", ad.to_store(time)
@@ -26,7 +26,7 @@ class Aggregate::Attribute::DateTimeTest < ActiveSupport::TestCase
 
   should "handle parsing and storing datetime based on format option" do
     ad   = Aggregate::AttributeHandler.factory("testme", :datetime, format: :short)
-    time = Time.at(1544732833).in_time_zone("Pacific Time (US & Canada)")
+    time = Time.at(1_544_732_833).in_time_zone("Pacific Time (US & Canada)")
 
     assert_equal "12/13/18   8:27 PM", ad.from_value(time.iso8601).utc.to_s
     assert_equal "13 Dec 20:27", ad.to_store(time)
@@ -34,7 +34,7 @@ class Aggregate::Attribute::DateTimeTest < ActiveSupport::TestCase
 
   should "prefer :format over :aggregate_db_storage_type option" do
     ad   = Aggregate::AttributeHandler.factory("testme", :datetime, format: :short, aggregate_db_storage_type: :elasticsearch)
-    time = Time.at(1544732833).in_time_zone("Pacific Time (US & Canada)")
+    time = Time.at(1_544_732_833).in_time_zone("Pacific Time (US & Canada)")
 
     assert_equal "12/13/18   8:27 PM", ad.from_value(time.iso8601).utc.to_s
     assert_equal "13 Dec 20:27", ad.to_store(time)

--- a/test/unit/attribute/foreign_key_test.rb
+++ b/test/unit/attribute/foreign_key_test.rb
@@ -10,9 +10,11 @@ class Aggregate::Attribute::ForeignKeyTest < ActiveSupport::TestCase
 
       ad = Aggregate::AttributeHandler.belongs_to_factory("testme", class_name: "Passport")
 
-      assert_equal passport,         ad.from_value(passport)
-      assert_equal passport,         ad.from_value(passport.id)
-      assert_equal passport,         ad.from_store(passport.id)
+      assert_equal passport,         ad.from_value(passport).value
+      assert_equal passport.id,      ad.from_value(passport).id
+      assert_equal passport,         ad.from_value(passport.id).value
+      assert_equal passport.id,      ad.from_value(passport.id).id
+      assert_equal passport,         ad.from_store(passport.id).value
       assert_equal passport.id,      ad.to_store(passport)
 
       assert_nil             ad.from_value(nil)

--- a/test/unit/foreign_key_reference_test.rb
+++ b/test/unit/foreign_key_reference_test.rb
@@ -1,0 +1,41 @@
+# frozen_string_literal: true
+
+require_relative '../test_helper'
+
+class Aggregate::ForeignKeyReferenceTest < ActiveSupport::TestCase
+
+  context "when constructed with an ID" do
+    setup do
+      @passport = sample_passport
+      Passport.initialization_count = 0
+
+      @reference = Aggregate::ForeignKeyReference.new(Passport, @passport.id)
+    end
+
+    should "not load the instance to read the id" do
+      assert_equal @passport.id, @reference.id
+      assert_equal 0, Passport.initialization_count
+    end
+
+    should "load the instance when returning the instance" do
+      assert_equal @passport.name, @reference.value.name
+      assert_equal 1, Passport.initialization_count
+    end
+  end
+
+  context "when constructed with an instance" do
+    setup do
+      @passport = sample_passport
+      Passport.initialization_count = 0
+
+      @reference = Aggregate::ForeignKeyReference.new(Passport, @passport)
+    end
+
+    should "not load the instance when reading the instance or the id" do
+      assert_equal @passport.id, @reference.id
+      assert_equal @passport.name, @reference.value.name
+
+      assert_equal 0, Passport.initialization_count
+    end
+  end
+end


### PR DESCRIPTION
Alec and Omeed - This is a quick fix to not load the foreign key class when reading the id values from aggregate belongs_to fields.   

A future iteration will try to consolidate the queries so that we load all instances when we load the first.  But I want to hold off on that so we can get this out earlier. 