### PR TITLE
STORY-6805 change history remove stub data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 All notable changes to this project will be documented in this file.
-## [1.1.0] - 2019-03-13
+## [1.0.1] - 2019-03-13
 ### Changed
 - Update `required` option for attributes to only raise an error when `nil` is given. This is to allow supplying `false` for boolean fields.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,13 @@
-# Changelog 
-All notable changes to this project will be documented in this file. 
-## [1.0.0] - 2019-01-15 
-### Changed 
-- Require `store_aggregates_using` or `store_aggregates_using_large_text_field` usage when using `Aggregate::Container` in order to move away from writing to `large_text_fields`. This is not backwards compatible as all classes using `Aggregate::Container` will need to be updated. 
-## [0.2.0] - 2019-01-14 
-### Added 
+# Changelog
+All notable changes to this project will be documented in this file.
+## [1.1.0] - 2019-03-13
+### Changed
+- Update `required` option for attributes to only raise an error when `nil` is given. This is to allow supplying `false` for boolean fields.
+
+## [1.0.0] - 2019-01-15
+### Changed
+- Require `store_aggregates_using` or `store_aggregates_using_large_text_field` usage when using `Aggregate::Container` in order to move away from writing to `large_text_fields`. This is not backwards compatible as all classes using `Aggregate::Container` will need to be updated.
+
+## [0.2.0] - 2019-01-14
+### Added
 - Added initial entry in ChangeLog (see README at this point for gem details)

--- a/lib/aggregate/attribute/base.rb
+++ b/lib/aggregate/attribute/base.rb
@@ -43,7 +43,7 @@ module Aggregate
       def validation_errors(value)
         [
           ("is not in list (#{value.inspect} not in #{options[:limit].inspect})" if value && options[:limit] && !value.in?(options[:limit])),
-          ("must be set" if !value && options[:required])
+          ("must be set" if value.nil? && options[:required])
         ].compact
       end
 

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "1.1.0"
+  VERSION = "1.0.1"
 end

--- a/test/unit/attribute/base_test.rb
+++ b/test/unit/attribute/base_test.rb
@@ -42,6 +42,11 @@ class Aggregate::Attribute::BaseTest < ActiveSupport::TestCase
         assert_equal expected, ad.validation_errors(nil)
       end
 
+      should "allow 'false' for required field" do
+        ad = Aggregate::AttributeHandler.factory("testme", :boolean, required: true)
+        assert_equal [], ad.validation_errors(false)
+      end
+
       should "enforce limit" do
         ad = Aggregate::AttributeHandler.factory("testme", :enum, limit: [:red, :blue, :green])
         expected = ["is not in list (:azure not in [:red, :blue, :green])"]


### PR DESCRIPTION
## Details
Update `required` attribute option to only error out if `nil` is given. This is to allow supplying `false` for boolean fields.