### PR TITLE
no jira update hash json default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,8 +5,8 @@ All notable changes to this project will be documented in this file.
 - Change `store_hash_as_json` hash option to default to `true` for regardless of `aggregate_db_storage_type`
 
 ## [1.1] - ?
-### Changed
-- Missed
+### Added
+- `Aggregate::AggregateStore#aggregate_attribute_changes`
 
 ## [1.0.1] - 2019-03-13
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 All notable changes to this project will be documented in this file.
+## [1.2] - 2019-07-03
+### Changed
+- Change `store_hash_as_json` hash option to default to `true` for regardless of `aggregate_db_storage_type`
+
+## [1.1] - ?
+### Changed
+- Missed
+
 ## [1.0.1] - 2019-03-13
 ### Changed
 - Update `required` option for attributes to only raise an error when `nil` is given. This is to allow supplying `false` for boolean fields.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -19,7 +19,7 @@ GIT
 PATH
   remote: .
   specs:
-    aggregate (1.1)
+    aggregate (1.2)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       hobo_support (= 2.0.1)

--- a/lib/aggregate/attribute/hash.rb
+++ b/lib/aggregate/attribute/hash.rb
@@ -75,7 +75,7 @@ module Aggregate
         if options.key?(:store_hash_as_json)
           options[:store_hash_as_json]
         else
-          options.dig(:aggregate_db_storage_type) != :elasticsearch
+          true
         end
       end
     end

--- a/lib/aggregate/attribute/hash.rb
+++ b/lib/aggregate/attribute/hash.rb
@@ -72,11 +72,7 @@ module Aggregate
       end
 
       def should_store_hash_as_json
-        if options.key?(:store_hash_as_json)
-          options[:store_hash_as_json]
-        else
-          true
-        end
+        options[:store_hash_as_json].nil? || options[:store_hash_as_json]
       end
     end
   end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "1.1"
+  VERSION = "1.2"
 end

--- a/test/unit/attribute/hash_test.rb
+++ b/test/unit/attribute/hash_test.rb
@@ -77,6 +77,14 @@ class Aggregate::Attribute::HashTest < ActiveSupport::TestCase
         should "keep json strings" do
           assert_equal "{}", @ad.store("{}")
         end
+
+        should "store nil as default empty JSON string" do
+          assert_equal "{}", @ad.store(nil)
+        end
+
+        should "store empty string as empty string" do
+          assert_equal "", @ad.store("")
+        end
       end
 
       context "store_hash_as_json as false" do
@@ -98,35 +106,6 @@ class Aggregate::Attribute::HashTest < ActiveSupport::TestCase
 
         should "set empty string as default value" do
           assert_equal({}, @attribute_handler.store(""))
-        end
-      end
-
-      context "aggregate_db_storage_type option as :elasticsearch" do
-        setup do
-          @attribute_handler = Aggregate::AttributeHandler.factory("testme", :hash, aggregate_db_storage_type: :elasticsearch)
-        end
-
-        should "encode hash values as hashes" do
-          assert_equal({ a: 1 }, @attribute_handler.store(a: 1))
-        end
-
-        should "expand json strings as hashes" do
-          assert_equal({ "a" => 1 }, @attribute_handler.store("{\"a\":1}"))
-        end
-
-        should "set default value as empty hash" do
-          assert_equal({}, @attribute_handler.store(nil))
-        end
-
-        should "set empty string as default value" do
-          assert_equal({}, @attribute_handler.store(""))
-        end
-      end
-
-      context "supplying both :store_hash_as_json and :aggregate_db_storage_type options" do
-        should "prefer store_hash_as_json over aggregate_db_storage_type" do
-          attr_handler = Aggregate::AttributeHandler.factory("testme", :hash, store_hash_as_json: true, aggregate_db_storage_type: :elasticsearch)
-          assert_equal "{\"a\":1}", attr_handler.store(a: 1)
         end
       end
     end

--- a/test/unit/attribute/hash_test.rb
+++ b/test/unit/attribute/hash_test.rb
@@ -87,6 +87,30 @@ class Aggregate::Attribute::HashTest < ActiveSupport::TestCase
         end
       end
 
+      [nil, true].each do |value|
+        context "store_hash_as_json as true (via #{value.inspect})" do
+          setup do
+            @attribute_handler = Aggregate::AttributeHandler.factory("testme", :hash, store_hash_as_json: value)
+          end
+
+          should "encode hash values as json" do
+            assert_equal "{}", @ad.store({})
+          end
+
+          should "keep json strings" do
+            assert_equal "{}", @ad.store("{}")
+          end
+
+          should "store nil as default empty JSON string" do
+            assert_equal "{}", @ad.store(nil)
+          end
+
+          should "store empty string as empty string" do
+            assert_equal "", @ad.store("")
+          end
+        end
+      end
+
       context "store_hash_as_json as false" do
         setup do
           @attribute_handler = Aggregate::AttributeHandler.factory("testme", :hash, store_hash_as_json: false)


### PR DESCRIPTION
### Details
* Update `store_hash_as_json` default to be true regardless of storage type
  * This is so that elasticsearch models will by default store `hash` fields as JSON blobs without requiring `store_hash_as_json: true` to be set. This is to avoid inadvertently falling into the problem where a hash attribute creates an unnamed Elasticsearch document field which is untracked and may easily cause a field name collision.