### PR TITLE
No jira relax hobo support dependency constraint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,8 +6,6 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
-gem 'large_text_field', '0.3.0.pre.1'
-
 group :development do
   gem 'invoca-utils', '0.0.2'
   gem 'sqlite3'

--- a/Gemfile
+++ b/Gemfile
@@ -6,9 +6,7 @@ gemspec
 # jquery-rails is used by the dummy application
 gem "jquery-rails"
 
-gem 'encryptor',            '3.0.0'
 gem 'large_text_field', '0.3.0.pre.1'
-gem 'protected_attributes', '1.1.3'
 
 group :development do
   gem 'invoca-utils', '0.0.2'

--- a/Gemfile
+++ b/Gemfile
@@ -7,8 +7,7 @@ gemspec
 gem "jquery-rails"
 
 gem 'encryptor',            '3.0.0'
-gem 'hobo_support',         '2.0.1',  git: 'git@github.com:Invoca/hobosupport',           ref: 'b9086322274b474a2b5bae507c4885e55d4aa050'
-gem 'large_text_field',               git: 'git@github.com:Invoca/large_text_field.git',  ref: '2efc950395352bf8b7f45891122f6bc42b171526'
+gem 'large_text_field', '0.3.0.pre.1'
 gem 'protected_attributes', '1.1.3'
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,7 +132,7 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sprockets (4.0.0)
+    sprockets (3.7.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,12 +155,10 @@ PLATFORMS
 
 DEPENDENCIES
   aggregate!
-  encryptor (= 3.0.0)
   invoca-utils (= 0.0.2)
   jquery-rails
   large_text_field (= 0.3.0.pre.1)
   minitest (~> 5.1)
-  protected_attributes (= 1.1.3)
   pry
   rr (= 1.1.2)
   rubocop

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
-    large_text_field (0.3.0.pre.1)
+    large_text_field (0.3.0)
       hobo_support (~> 2.2)
       protected_attributes (~> 1.1)
       rails (~> 4.2)
@@ -157,7 +157,6 @@ DEPENDENCIES
   aggregate!
   invoca-utils (= 0.0.2)
   jquery-rails
-  large_text_field (= 0.3.0.pre.1)
   minitest (~> 5.1)
   pry
   rr (= 1.1.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,28 +1,10 @@
-GIT
-  remote: git@github.com:Invoca/hobosupport
-  revision: b9086322274b474a2b5bae507c4885e55d4aa050
-  ref: b9086322274b474a2b5bae507c4885e55d4aa050
-  specs:
-    hobo_support (2.0.1)
-      rails (~> 4.2.10)
-
-GIT
-  remote: git@github.com:Invoca/large_text_field.git
-  revision: 2efc950395352bf8b7f45891122f6bc42b171526
-  ref: 2efc950395352bf8b7f45891122f6bc42b171526
-  specs:
-    large_text_field (0.2.0)
-      hobo_support (= 2.0.1)
-      protected_attributes
-      rails (~> 4.2)
-
 PATH
   remote: .
   specs:
     aggregate (1.2)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
-      hobo_support (= 2.0.1)
+      hobo_support (~> 2.2)
       large_text_field (~> 0.2)
 
 GEM
@@ -70,8 +52,10 @@ GEM
     crass (1.0.4)
     encryptor (3.0.0)
     erubis (2.7.0)
-    globalid (0.4.1)
+    globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hobo_support (2.2.6)
+      rails (~> 4.2.6)
     i18n (0.9.1)
       concurrent-ruby (~> 1.0)
     invoca-utils (0.0.2)
@@ -80,13 +64,17 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    large_text_field (0.3.0.pre.1)
+      hobo_support (~> 2.2)
+      protected_attributes (~> 1.1)
+      rails (~> 4.2)
     loofah (2.2.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
-    mail (2.7.0)
+    mail (2.7.1)
       mini_mime (>= 0.1.1)
     method_source (0.9.0)
-    mini_mime (1.0.0)
+    mini_mime (1.0.2)
     mini_portile2 (2.3.0)
     minitest (5.11.1)
     nokogiri (1.8.4)
@@ -144,7 +132,7 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sprockets (3.7.2)
+    sprockets (4.0.0)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -168,10 +156,9 @@ PLATFORMS
 DEPENDENCIES
   aggregate!
   encryptor (= 3.0.0)
-  hobo_support (= 2.0.1)!
   invoca-utils (= 0.0.2)
   jquery-rails
-  large_text_field!
+  large_text_field (= 0.3.0.pre.1)
   minitest (~> 5.1)
   protected_attributes (= 1.1.3)
   pry

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activerecord",     "~> 4.0"
   s.add_dependency "encryptor",        "~> 3.0"
-  s.add_dependency "hobo_support",     "2.0.1"
+  s.add_dependency "hobo_support",     "~> 2.2"
   s.add_dependency "large_text_field", "~> 0.2"
 end

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "encryptor"
 require "active_record"
 
 require "aggregate/bitfield"


### PR DESCRIPTION
This is necessary to unblock our Gemfury conversion.