### PR TITLE
No-Jira: relax hobo_support version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     aggregate (1.2)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
-      hobo_support (~> 2.2)
+      hobo_support (~> 2.0)
       large_text_field (~> 0.2)
 
 GEM
@@ -83,7 +83,7 @@ GEM
     parser (2.6.5.0)
       ast (~> 2.4.0)
     power_assert (1.1.1)
-    protected_attributes (1.1.3)
+    protected_attributes (1.1.4)
       activemodel (>= 4.0.1, < 5.0)
     pry (0.11.3)
       coderay (~> 1.1.0)

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -20,6 +20,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activerecord",     "~> 4.0"
   s.add_dependency "encryptor",        "~> 3.0"
-  s.add_dependency "hobo_support",     "~> 2.2"
+  s.add_dependency "hobo_support",     "~> 2.0"
   s.add_dependency "large_text_field", "~> 0.2"
 end


### PR DESCRIPTION
These changes needed to unblock downstream consumers. 

This gem doesn't care what version of hobo_support is available, so long as version >= 2.0.0 is available.
