### PR TITLE
2004/web 4995 kibana document timestamps do not show milliseconds final approach

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Inspired by [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 All notable changes to this project will be documented in this file.
+## [2.0.0] - 2020-04-29
+### Changed
+- Change `Aggregate::Attribute::DateTime` to use 3 decimal places (millisecond precision) when `:aggregate_db_storage_type == :elasticsearch`
+
 ## [1.2.2] - 2020-04-28
 ### Changed
 - Bumped invoca-utils to 0.3.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (1.2.2)
+    aggregate (2.0.0)
       activerecord (~> 4.0)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/attribute/date_time.rb
+++ b/lib/aggregate/attribute/date_time.rb
@@ -13,7 +13,7 @@ class Aggregate::Attribute::DateTime < Aggregate::Attribute::Builtin
     if @options[:format]
       value.utc.to_s(@options[:format])
     elsif @options.dig(:aggregate_db_storage_type) == :elasticsearch
-      value.utc.iso8601
+      value.utc.iso8601(3)
     else
       value.utc.rfc822
     end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "1.2.2"
+  VERSION = "2.0.0"
 end

--- a/test/unit/attribute/date_time_test.rb
+++ b/test/unit/attribute/date_time_test.rb
@@ -18,10 +18,10 @@ class Aggregate::Attribute::DateTimeTest < ActiveSupport::TestCase
 
   should "handle parsing and storing datetime based on aggregate_db_storage_type option being :elasticsearch" do
     ad   = Aggregate::AttributeHandler.factory("testme", :datetime, aggregate_db_storage_type: :elasticsearch)
-    time = Time.at(1_544_732_833).in_time_zone("Pacific Time (US & Canada)")
+    time = Time.at(1_544_732_833.1234).in_time_zone("Pacific Time (US & Canada)")
 
     assert_equal "12/13/18   8:27 PM", ad.from_value(time.iso8601).utc.to_s
-    assert_equal "2018-12-13T20:27:13Z", ad.to_store(time)
+    assert_equal "2018-12-13T20:27:13.123Z", ad.to_store(time)
   end
 
   should "handle parsing and storing datetime based on format option" do


### PR DESCRIPTION
https://github.com/Invoca/web/pull/12612
https://github.com/Invoca/elasticsearch_models/pull/23