### PR TITLE
Tech 4591 rails 5 bundle install working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.1] - Unreleased
+### Fixed
+- Fixed bug in Rails 5+ where `Aggregate::Base` and `Aggregate::Container` no longer had access to
+callbacks defined by `ActiveRecord`
+
 ## [2.1.0] - 2020-05-28
 ### Added
 - Added support for rails 5 and 6.
@@ -48,6 +53,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 - Added initial entry in ChangeLog (see README at this point for gem details)
 
+[2.1.1]: https://github.com/Invoca/aggregate/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Invoca/aggregate/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/Invoca/aggregate/compare/v2.0.0...v2.0.1
 [2.0.0]: https://github.com/Invoca/aggregate/compare/v1.2.2...v2.0.0

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.1.0)
+    aggregate (2.1.1)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)
@@ -61,7 +61,7 @@ GEM
       activesupport (>= 4.2.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
-    invoca-utils (0.3.0)
+    invoca-utils (0.4.1)
     jaro_winkler (1.5.4)
     jquery-rails (4.3.1)
       rails-dom-testing (>= 1, < 3)
@@ -137,7 +137,7 @@ GEM
     shoulda-context (1.2.2)
     shoulda-matchers (2.8.0)
       activesupport (>= 3.0.0)
-    sprockets (4.0.0)
+    sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
     sprockets-rails (3.2.1)
@@ -173,4 +173,4 @@ DEPENDENCIES
   test_after_commit
 
 BUNDLED WITH
-   1.17.2
+   1.17.3

--- a/lib/aggregate.rb
+++ b/lib/aggregate.rb
@@ -2,6 +2,9 @@
 
 require "encryptor"
 require "active_record"
+if ActiveRecord::VERSION::MAJOR > 4
+  require 'active_record/define_callbacks'
+end
 
 require "aggregate/bitfield"
 

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -16,7 +16,7 @@ module Aggregate
     include ActiveRecord::Reflection
     include Comparable
 
-    if Rails::VERSION::MAJOR > 4
+    if ActiveRecord::VERSION::MAJOR > 4
       include ActiveRecord::DefineCallbacks
     end
 

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -16,6 +16,10 @@ module Aggregate
     include ActiveRecord::Reflection
     include Comparable
 
+    if Rails::VERSION::MAJOR > 4
+      include ActiveRecord::DefineCallbacks
+    end
+
     validate :validate_aggregates
 
     define_callbacks :before_validation, :aggregate_load, :aggregate_load_check_schema

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -8,7 +8,7 @@ module Aggregate
     include ActiveSupport::Callbacks
     include Aggregate::AggregateStore
 
-    if Rails::VERSION::MAJOR > 4
+    if ActiveRecord::VERSION::MAJOR > 4
       include ActiveRecord::DefineCallbacks
     end
 

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -8,6 +8,10 @@ module Aggregate
     include ActiveSupport::Callbacks
     include Aggregate::AggregateStore
 
+    if Rails::VERSION::MAJOR > 4
+      include ActiveRecord::DefineCallbacks
+    end
+
     class StorageAlreadyDefined < ArgumentError; end
 
     # rubocop:disable Metrics/BlockLength

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.1.0"
+  VERSION = "2.1.1"
 end


### PR DESCRIPTION
## [2.1.1] - Unreleased
### Fixed
- Fixed bug in Rails 5+ where `Aggregate::Base` and `Aggregate::Container` no longer had access to
callbacks defined by `ActiveRecord`