### PR TITLE
WEB-5236: Fix aggregate attribute changes when more than one change h…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.2] - Unreleased
+### Fixed
+- Fixed a bug where `Aggregate::AggregateStore#aggregate_attribute_changes` would show incorrect changes across database transactions
+
 ## [2.1.1] - 2020-08-31
 ### Fixed
 - Fixed bug in Rails 5+ where `Aggregate::Base` and `Aggregate::Container` no longer had access to

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.1.1)
+    aggregate (2.1.2.pre.2)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)
@@ -140,7 +140,7 @@ GEM
     sprockets (4.0.2)
       concurrent-ruby (~> 1.0)
       rack (> 1, < 3)
-    sprockets-rails (3.2.1)
+    sprockets-rails (3.2.2)
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -109,6 +109,7 @@ module Aggregate
     def reset_changed_cache
       @changed = nil
       @aggregate_changes = nil
+      @aggregate_initial_values = @aggregate_values.dup
     end
 
     def aggregate_store_data

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.1.1"
+  VERSION = "2.1.2.pre.2"
 end

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -846,6 +846,16 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       assert_not passport.changed?
     end
 
+    should "correctly display changes across transactions" do
+      passport = sample_passport
+      passport.weight = 50
+      assert_equal ({ "weight" => [100, 50] }), passport.aggregate_attribute_changes
+      passport.save!
+
+      passport.weight = 75
+      assert_equal ({ "weight" => [50, 75] }), passport.aggregate_attribute_changes
+    end
+
     should "load the decoded aggregate store on destroy if using large text field" do
       passport = sample_passport
       assert_not passport.reload.instance_variable_get(:@decoded_aggregate_store_loaded)


### PR DESCRIPTION
…as been made

[Jira ticket](https://ringrevenue.atlassian.net/browse/WEB-5236)

The `AggregateStore` class has an `aggregate_attribute_changes` method that is used by ChangeHistory to record changes made to aggregate attributes. When adding ChangeHistory for Bing in [STORY-8911](https://ringrevenue.atlassian.net/browse/STORY-8911), it was noticed that if more than one change was made to an attribute, the changes were not correctly displaying.

For example, if a BingOrgConfig was created with `approved = true`, `aggregate_attribute_changes` would show the attribute going from `false => true` (because `false` is the default). If `approved` was then updated to be `false`, `aggregate_attribute_changes` said the attribute changed, but went from `false => false`.

### Changes
This was fixed by updating the `@aggregate_initial_values` variable to be equal to `@aggregate_values` on a database commit. This resets the initial values to what is stored, so when they are referenced to see what was changed on future changes, the changes will be displayed correctly.

[Web PR](https://github.com/Invoca/web/pull/14341)