### PR TITLE
Web 5237 aggregate attribute changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.1.3] - Unrelease
+### Fixed
+- Fixed a bug where `Aggregate::AggregateStore#aggregate_attribute_changes` and `Aggregate::AggregateStore#changed?` would show incorrect changes.
+Ensures that the correct state is represented when a field is changed from and back to it's initial value.
+  
+
 ## [2.1.2] - 2020-11-23
 ### Fixed
 - Fixed a bug where `Aggregate::AggregateStore#aggregate_attribute_changes` would show incorrect changes across database transactions

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ All notable changes to this project will be documented in this file.
 Ensures that the correct state is represented when a field is changed from and back to it's initial value.
 - Fixed a bug where changes to aggregate attributes during an aggregate schema fixup were being marked as changes.
   - These are seen as data migrations and thus are not changes to the model itself, but a transformation
+- Fixed a bug where `aggregate_has_many` attribute was not being marked as changed if one of its containing values changed  
 
 ## [2.1.2] - 2020-11-23
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,8 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Fixed a bug where `Aggregate::AggregateStore#aggregate_attribute_changes` and `Aggregate::AggregateStore#changed?` would show incorrect changes.
 Ensures that the correct state is represented when a field is changed from and back to it's initial value.
-  
+- Fixed a bug where changes to aggregate attributes during an aggregate schema fixup were being marked as changes.
+  - These are seen as data migrations and thus are not changes to the model itself, but a transformation
 
 ## [2.1.2] - 2020-11-23
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.1.3.pre.1)
+    aggregate (2.1.3.pre.2)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.1.2)
+    aggregate (2.1.3.pre.0)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.1.3.pre.0)
+    aggregate (2.1.3.pre.1)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -175,7 +175,7 @@ module Aggregate
     end
 
     def aggregate_attribute_changed?(agg_attribute)
-      aggregate_changes[agg_attribute.name] || aggregate_values[agg_attribute.name].try(:changed?)
+      aggregate_changes[agg_attribute.name] || Array.wrap(aggregate_values[agg_attribute.name]).any? { |value| value.try(:changed?) }
     end
 
     def aggregate_attribute_before_type_cast(agg_attribute)

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -76,7 +76,7 @@ module Aggregate
     end
 
     def set_changed
-      @changed = true
+      @changed = aggregate_values != aggregate_initial_values
       aggregate_owner&.set_changed
     end
 
@@ -164,9 +164,10 @@ module Aggregate
     def save_aggregate_attribute(agg_attribute, value)
       aggregate = agg_attribute.from_value(value)
       if aggregate != load_aggregate_attribute(agg_attribute)
-        aggregate_values_before_cast[agg_attribute.name] = value
-        aggregate_values[agg_attribute.name] = aggregate
-        aggregate_changes[agg_attribute.name] = true
+        name = agg_attribute.name
+        aggregate_values_before_cast[name] = value
+        aggregate_values[name]             = aggregate
+        aggregate_changes[name]            = aggregate != aggregate_initial_values[name]
         set_aggregate_owner(agg_attribute, aggregate)
         set_changed
       end

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -21,6 +21,7 @@ module Aggregate
       send(:define_callbacks, :aggregate_load_schema)
       send(:define_callbacks, :aggregate_load_check_schema)
       set_callback :commit, :after, :reset_changed_cache
+      set_callback :aggregate_load_check_schema, :after, :reset_changed_cache
       class_attribute :aggregate_storage_field
       class_attribute :migrate_from_storage_field
 

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.1.3.pre.0"
+  VERSION = "2.1.3.pre.1"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.1.3.pre.1"
+  VERSION = "2.1.3.pre.2"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.1.2"
+  VERSION = "2.1.3.pre.0"
 end

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -231,13 +231,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "support building with nested attributes" do
         @doc = TestPurchase.new
         @doc.build_first_shipment(
-          tracking_number:  '1245',
+          tracking_number: '1245',
           weight_in_ounces: 5,
-          ship_from:        {
-            full_name:   'Lisa Smith',
+          ship_from: {
+            full_name: 'Lisa Smith',
             address_one: '1812 Clearview Road',
             address_two: '',
-            zip:         '93101'
+            zip: '93101'
           }
         )
 
@@ -249,13 +249,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "support building with strings instead of symbols" do
         @doc = TestPurchase.new
         @doc.build_first_shipment(
-          'tracking_number'  => '1245',
+          'tracking_number' => '1245',
           'weight_in_ounces' => 5,
-          'ship_from'        => {
-            'full_name'   => 'Lisa Smith',
+          'ship_from' => {
+            'full_name' => 'Lisa Smith',
             'address_one' => '1812 Clearview Road',
             'address_two' => '',
-            'zip'         => '93101'
+            'zip' => '93101'
           }
         )
 
@@ -278,13 +278,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "be able to find the root_aggregate_owner" do
         @doc = TestPurchase.new
         @doc.build_first_shipment(
-          tracking_number:  '1245',
+          tracking_number: '1245',
           weight_in_ounces: 5,
-          ship_from:        {
-            full_name:   'Lisa Smith',
+          ship_from: {
+            full_name: 'Lisa Smith',
             address_one: '1812 Clearview Road',
             address_two: '',
-            zip:         '93101'
+            zip: '93101'
           }
         )
 
@@ -312,13 +312,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     should "report when any attributes have been changed" do
       json = {
         'first_shipment' => {
-          'tracking_number'  => '1245',
+          'tracking_number' => '1245',
           'weight_in_ounces' => 5,
-          'ship_from'        => {
-            'full_name'   => 'Lisa Smith',
+          'ship_from' => {
+            'full_name' => 'Lisa Smith',
             'address_one' => '1812 Clearview Road',
             'address_two' => '',
-            'zip'         => '93101'
+            'zip' => '93101'
           }
         }
       }.to_json
@@ -343,13 +343,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "marshal to json" do
         json = {
           'first_shipment' => {
-            'tracking_number'  => '1245',
+            'tracking_number' => '1245',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           }
         }.to_json
@@ -357,18 +357,19 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
         expected = {
           "data_schema_version" => "2.0",
-          "test_string"         => nil,
-          "second_shipment"     => nil,
-          "first_shipment"      => {
+          "test_string" => nil,
+          "second_shipment" => nil,
+          "first_shipment" => {
             "ship_from" => {
-              "zip"         => "93101",
+              "zip" => "93101",
               "address_two" => "",
               "address_one" => "1812 Clearview Road",
-              "full_name"   => "Lisa Smith"
+              "full_name" => "Lisa Smith"
             },
-            "tracking_number"  => "1245",
+            "tracking_number" => "1245",
             "weight_in_ounces" => 5
-          }
+          },
+          "after_schema_fixup" => nil
         }
         assert_equal expected, @doc.to_store
 
@@ -411,14 +412,14 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
         should "support load save and assign" do
           json = {
             'first_shipment' => {
-              'tracking_number'  => '1245',
+              'tracking_number' => '1245',
               'weight_in_ounces' => 5,
-              'shipping_method'  => 'UsPostal',
-              'ship_from'        => {
-                'full_name'   => 'Lisa Smith',
+              'shipping_method' => 'UsPostal',
+              'ship_from' => {
+                'full_name' => 'Lisa Smith',
                 'address_one' => '1812 Clearview Road',
                 'address_two' => '',
-                'zip'         => '93101'
+                'zip' => '93101'
               }
             }
           }.to_json
@@ -430,19 +431,20 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
           expected = {
             "data_schema_version" => "2.0",
-            "test_string"         => nil,
-            "second_shipment"     => nil,
-            "first_shipment"      => {
+            "test_string" => nil,
+            "second_shipment" => nil,
+            "first_shipment" => {
               "ship_from" => {
-                "zip"         => "93101",
+                "zip" => "93101",
                 "address_two" => "",
                 "address_one" => "1812 Clearview Road",
-                "full_name"   => "Lisa Smith"
+                "full_name" => "Lisa Smith"
               },
-              "tracking_number"  => "1245",
+              "tracking_number" => "1245",
               "weight_in_ounces" => 5,
-              "shipping_method"  => "UPS"
-            }
+              "shipping_method" => "UPS"
+            },
+            "after_schema_fixup" => nil
           }
           assert_equal expected, @doc.to_store
 
@@ -458,15 +460,15 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
         should "support load save and assign" do
           json = {
             'first_shipment' => {
-              'tracking_number'    => '1245',
-              'weight_in_ounces'   => 5,
-              'shipping_method'    => 'UsPostal',
+              'tracking_number' => '1245',
+              'weight_in_ounces' => 5,
+              'shipping_method' => 'UsPostal',
               'signature_required' => false,
-              'ship_from'          => {
-                'full_name'   => 'Lisa Smith',
+              'ship_from' => {
+                'full_name' => 'Lisa Smith',
                 'address_one' => '1812 Clearview Road',
                 'address_two' => '',
-                'zip'         => '93101'
+                'zip' => '93101'
               }
             }
           }.to_json
@@ -493,20 +495,21 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
           expected = {
             "data_schema_version" => "2.0",
-            "test_string"         => nil,
-            "second_shipment"     => nil,
-            "first_shipment"      => {
+            "test_string" => nil,
+            "second_shipment" => nil,
+            "first_shipment" => {
               "ship_from" => {
-                "zip"         => "93101",
+                "zip" => "93101",
                 "address_two" => "",
                 "address_one" => "1812 Clearview Road",
-                "full_name"   => "Lisa Smith"
+                "full_name" => "Lisa Smith"
               },
-              "tracking_number"    => "1245",
-              "weight_in_ounces"   => 5,
-              "shipping_method"    => "UsPostal",
+              "tracking_number" => "1245",
+              "weight_in_ounces" => 5,
+              "shipping_method" => "UsPostal",
               "signature_required" => true
-            }
+            },
+            "after_schema_fixup" => nil
           }
           assert_equal expected, @doc.to_store
         end
@@ -519,16 +522,16 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
         should "support convert to the current time zone when loading" do
           json = {
             'first_shipment' => {
-              'tracking_number'    => '1245',
-              'weight_in_ounces'   => 5,
-              'shipping_method'    => 'UsPostal',
+              'tracking_number' => '1245',
+              'weight_in_ounces' => 5,
+              'shipping_method' => 'UsPostal',
               'signature_required' => false,
-              'shipped_at'         => "2012/04/18 17:50:08 -0700",
-              'ship_from'          => {
-                'full_name'   => 'Lisa Smith',
+              'shipped_at' => "2012/04/18 17:50:08 -0700",
+              'ship_from' => {
+                'full_name' => 'Lisa Smith',
                 'address_one' => '1812 Clearview Road',
                 'address_two' => '',
-                'zip'         => '93101'
+                'zip' => '93101'
               }
             }
           }.to_json
@@ -580,15 +583,15 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
         should "support load save and assign" do
           json = {
             'first_shipment' => {
-              'tracking_number'  => '1245',
+              'tracking_number' => '1245',
               'weight_in_ounces' => 5,
-              'shipping_method'  => 'UsPostal',
-              'postage_due'      => '1001.10',
-              'ship_from'        => {
-                'full_name'   => 'Lisa Smith',
+              'shipping_method' => 'UsPostal',
+              'postage_due' => '1001.10',
+              'ship_from' => {
+                'full_name' => 'Lisa Smith',
                 'address_one' => '1812 Clearview Road',
                 'address_two' => '',
-                'zip'         => '93101'
+                'zip' => '93101'
               }
             }
           }.to_json
@@ -600,20 +603,21 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
           expected = {
             "data_schema_version" => "2.0",
-            "test_string"         => nil,
-            "second_shipment"     => nil,
-            "first_shipment"      => {
+            "test_string" => nil,
+            "second_shipment" => nil,
+            "first_shipment" => {
               "ship_from" => {
-                "zip"         => "93101",
+                "zip" => "93101",
                 "address_two" => "",
                 "address_one" => "1812 Clearview Road",
-                "full_name"   => "Lisa Smith"
+                "full_name" => "Lisa Smith"
               },
-              "tracking_number"  => "1245",
+              "tracking_number" => "1245",
               "weight_in_ounces" => 5,
-              "shipping_method"  => "UsPostal",
-              "postage_due"      => '50.2'
-            }
+              "shipping_method" => "UsPostal",
+              "postage_due" => '50.2'
+            },
+            "after_schema_fixup" => nil
           }
           assert_equal expected, @doc.to_store
         end
@@ -624,14 +628,14 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       setup do
         @doc = TestPurchase.new
         @doc.build_first_shipment(
-          tracking_number:  '1245',
+          tracking_number: '1245',
           weight_in_ounces: 5,
-          postage_due:      10.0,
-          ship_from:        {
-            full_name:   'Lisa Smith',
+          postage_due: 10.0,
+          ship_from: {
+            full_name: 'Lisa Smith',
             address_one: '1812 Clearview Road',
             address_two: '',
-            zip:         '93101'
+            zip: '93101'
           }
         )
       end
@@ -639,12 +643,12 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "enforce required fields" do
         @doc.build_first_shipment(
           tracking_number: '1245',
-          postage_due:     10.0,
-          ship_from:       {
-            full_name:   'Lisa Smith',
+          postage_due: 10.0,
+          ship_from: {
+            full_name: 'Lisa Smith',
             address_one: '1812 Clearview Road',
             address_two: '',
-            zip:         '93101'
+            zip: '93101'
           }
         )
 
@@ -674,13 +678,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "fire callbacks when loaded" do
         json = {
           'first_shipment' => {
-            'tracking_number'  => '9999',
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           }
         }.to_json
@@ -698,13 +702,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "fire schema version callbacks if schema is missing" do
         json = {
           'first_shipment' => {
-            'tracking_number'  => '9999',
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           }
         }.to_json
@@ -719,13 +723,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "fire schema version callbacks if schema does not match" do
         json = {
           'first_shipment' => {
-            'tracking_number'  => '9999',
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           },
           "data_schema_version" => "1.9"
@@ -741,13 +745,13 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "not mark schema migration attribute changes as changes" do
         json = {
           'first_shipment' => {
-            'tracking_number'  => '9999',
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           },
           "data_schema_version" => "1.9"
@@ -764,14 +768,14 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
       should "not fire schema version callbacks if schema matches" do
         json = {
-          'first_shipment'      => {
-            'tracking_number'  => '9999',
+          'first_shipment' => {
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           },
           "data_schema_version" => "2.0"
@@ -785,14 +789,14 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
       should "not fire twice" do
         json = {
-          'first_shipment'      => {
-            'tracking_number'  => '9999',
+          'first_shipment' => {
+            'tracking_number' => '9999',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           },
           "data_schema_version" => "1.9"
@@ -810,17 +814,17 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
 
       should "pass the schema value and not the assigned value when performing the upgrade" do
         json = {
-          'first_shipment'      => {
-            'tracking_number'  => '6666',
+          'first_shipment' => {
+            'tracking_number' => '6666',
             'weight_in_ounces' => 5,
-            'ship_from'        => {
-              'full_name'   => 'Lisa Smith',
+            'ship_from' => {
+              'full_name' => 'Lisa Smith',
               'address_one' => '1812 Clearview Road',
               'address_two' => '',
-              'zip'         => '93101'
+              'zip' => '93101'
             }
           },
-          "test_string"         => "initial value",
+          "test_string" => "initial value",
           "data_schema_version" => "1.9"
         }.to_json
 


### PR DESCRIPTION
Correctly mark `#aggregate_attribute_changes` and `#changed?` when a value is changed from and back to its initial value.

Ensures that we're following Rails behavior with our "dirty" attribute methods

[Web PR](https://github.com/Invoca/web/pull/14408)