### PR TITLE
Tech 5525 before save for saved changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.1.pre.1] - UNRELEASED
+### Fixed
+- Fixed a bug where `Aggregate::AggregateStore` saved change methods would not show correct changes for
+  all scenarios:
+  - `#saved_changes?`
+  - `#aggregate_attribute_saved_changes`
+  - `#saved_change_to_{attribute}?`
+- When a one of the methods is called while the save is still in progess, the change will show correctly
+
 ## [2.3.0] - 2021-03-04
 ### Added
 - Added support for `saved_changes?` in `Aggregate::AggregateStore` for rails 5.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
-## [2.3.1.pre.1] - UNRELEASED
+## [2.3.1.pre.2] - UNRELEASED
 ### Fixed
 - Fixed a bug where `Aggregate::AggregateStore` saved change methods would not show correct changes for
   all scenarios:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.3.0)
+    aggregate (2.3.1.pre.1)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.3.1.pre.1)
+    aggregate (2.3.1.pre.2)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -89,7 +89,7 @@ module Aggregate
       ActiveRecordHelpers::Version.if_version(
         active_record_4: -> { raise NoMethodError, "undefined method 'saved_changes?' for #{self}" }
       )
-      save_in_progress_check
+      ensure_saved_changes_up_to_date
       (defined?(super) && super) || @changed_on_save
     end
 
@@ -152,7 +152,7 @@ module Aggregate
       ActiveRecordHelpers::Version.if_version(
         active_record_4: -> { raise NoMethodError, "undefined method 'aggregate_attribute_saved_changes' for #{self}" }
       )
-      save_in_progress_check
+      ensure_saved_changes_up_to_date
       @saved_aggregate_changes || {}
     end
 
@@ -211,7 +211,7 @@ module Aggregate
     end
 
     def aggregate_attribute_saved_changed?(agg_attribute)
-      save_in_progress_check
+      ensure_saved_changes_up_to_date
       aggregate_attribute_saved_changes.include?(agg_attribute.name) ||
         Array.wrap(aggregate_values[agg_attribute.name]).any? { |value| value.try(:saved_changes?) }
     end
@@ -271,7 +271,7 @@ module Aggregate
       end_save
     end
 
-    def save_in_progress_check
+    def ensure_saved_changes_up_to_date
       if @aggregate_save_in_progress
         save_changes
       end

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -89,6 +89,7 @@ module Aggregate
       ActiveRecordHelpers::Version.if_version(
         active_record_4: -> { raise NoMethodError, "undefined method 'saved_changes?' for #{self}" }
       )
+      save_in_progress_check
       (defined?(super) && super) || @changed_on_save
     end
 
@@ -151,6 +152,7 @@ module Aggregate
       ActiveRecordHelpers::Version.if_version(
         active_record_4: -> { raise NoMethodError, "undefined method 'aggregate_attribute_saved_changes' for #{self}" }
       )
+      save_in_progress_check
       @saved_aggregate_changes || {}
     end
 
@@ -209,6 +211,7 @@ module Aggregate
     end
 
     def aggregate_attribute_saved_changed?(agg_attribute)
+      save_in_progress_check
       aggregate_attribute_saved_changes.include?(agg_attribute.name) ||
         Array.wrap(aggregate_values[agg_attribute.name]).any? { |value| value.try(:saved_changes?) }
     end
@@ -252,6 +255,25 @@ module Aggregate
       self.class.aggregated_attribute_handlers.each do |_, aa|
         agg_value = load_aggregate_attribute(aa)
         aa.assign_saved_changes(agg_value)
+      end
+    end
+
+    def start_save
+      @aggregate_save_in_progress = true
+    end
+
+    def end_save
+      @aggregate_save_in_progress = false
+    end
+
+    def save_changes
+      set_saved_changes
+      end_save
+    end
+
+    def save_in_progress_check
+      if @aggregate_save_in_progress
+        save_changes
       end
     end
   end

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -23,7 +23,10 @@ module Aggregate
       set_callback :commit, :after, :reset_changed_cache
       set_callback :aggregate_load_check_schema, :after, :reset_changed_cache
       ActiveRecordHelpers::Version.if_version(
-        active_record_gt_4: -> { set_callback :save, :after, :set_saved_changes }
+        active_record_gt_4: -> {
+          set_callback :save, :before, :start_save
+          set_callback :save, :after, :save_changes
+        }
       )
       class_attribute :aggregate_storage_field
       class_attribute :migrate_from_storage_field

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.3.1.pre.1"
+  VERSION = "2.3.1.pre.2"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.3.0"
+  VERSION = "2.3.1.pre.1"
 end

--- a/test/unit/aggregate_store_test.rb
+++ b/test/unit/aggregate_store_test.rb
@@ -367,7 +367,7 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
             end
           },
           active_record_4: -> {
-            should "raise NoMetthodError for attribute saved changes methods" do
+            should "raise NoMethodError for attribute saved changes methods" do
               assert_raise(NoMethodError) { @passport.saved_change_to_name? }
               assert_raise(NoMethodError) { @passport.saved_change_to_photo? }
               assert_raise(NoMethodError) { @passport.photo.saved_change_to_color? }

--- a/test/unit/aggregate_store_test.rb
+++ b/test/unit/aggregate_store_test.rb
@@ -148,6 +148,16 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
                 assert @passport.foreign_visits.first.saved_changes?
               end
             end
+
+            context "when save still in progress" do
+              should "still mark saved_changes? correctly" do
+                @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+                refute @passport.saved_changes?
+
+                @passport.send(:start_save)
+                assert @passport.saved_changes?
+              end
+            end
           end
         },
         active_record_4: -> {
@@ -264,19 +274,27 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
             assert @passport.foreign_visits_changed?, "foreign visits not changed"
           end
 
-          should "correctly mark the attribute as changed when saved" do
-            @passport.save
-            Aggregate::ActiveRecordHelpers::Version.if_version(
-              active_record_gt_4: -> {
+          Aggregate::ActiveRecordHelpers::Version.if_version(
+            active_record_gt_4: -> {
+              should "correctly mark the attribute as changed when saved" do
+                @passport.save
                 assert @passport.saved_change_to_foreign_visits?
                 assert @passport.foreign_visits.first.saved_change_to_country?
-              },
-              active_record_4: -> {
+              end
+
+              should "correctly mark the attribute as changed when save still in progress" do
+                @passport.send(:start_save)
+                assert @passport.saved_change_to_foreign_visits?
+                assert @passport.foreign_visits.first.saved_change_to_country?
+              end
+            },
+            active_record_4: -> {
+              should "raise NoMethodError for saved change attribute methods" do
                 assert_raise(NoMethodError) { @passport.saved_change_to_foreign_visits? }
                 assert_raise(NoMethodError) { @passport.foreign_visits.first.saved_change_to_country? }
-              }
-            )
-          end
+              end
+            }
+          )
         end
       end
 
@@ -313,31 +331,47 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
         assert @instance.aggregate_owner.change_called
       end
 
-      should "keep track of saved changes to the attribute" do
-        passport = sample_passport
-        passport.photo = PassportPhoto.new(color: false)
-        passport.save
-        passport.reload
+      context "for individual attribute saved changes" do
+        setup do
+          @passport = sample_passport
+          @passport.photo = PassportPhoto.new(color: false)
+          @passport.save
+          @passport.reload
+        end
+
         Aggregate::ActiveRecordHelpers::Version.if_version(
           active_record_gt_4: -> {
-            refute passport.saved_change_to_name?
-            refute passport.photo.saved_change_to_color?
+            should "keep track of saved changes to the attribute" do
+              refute @passport.saved_change_to_name?
+              refute @passport.saved_change_to_photo?
+              refute @passport.photo.saved_change_to_color?
+
+              @passport.name = "godzilla"
+              @passport.photo.color = true
+              @passport.save
+
+              assert @passport.saved_change_to_name?
+              assert @passport.saved_change_to_photo?
+              assert @passport.photo.saved_change_to_color?
+            end
+
+            should "keep track of saved changes when save is in progress" do
+              refute @passport.photo.saved_change_to_color?
+              refute @passport.saved_change_to_photo?
+
+              @passport.photo.color = true
+              @passport.photo.send(:start_save)
+
+              assert @passport.photo.saved_change_to_color?
+              assert @passport.saved_change_to_photo?
+            end
           },
           active_record_4: -> {
-            assert_raise(NoMethodError) { passport.saved_change_to_name? }
-            assert_raise(NoMethodError) { passport.photo.saved_change_to_color? }
-          }
-        )
-
-        passport.name = "godzilla"
-        passport.photo.color = true
-        passport.save
-
-        Aggregate::ActiveRecordHelpers::Version.if_version(
-          active_record_gt_4: -> {
-            assert passport.saved_change_to_name?
-            assert passport.saved_change_to_photo?
-            assert passport.photo.saved_change_to_color?
+            should "raise NoMetthodError for attribute saved changes methods" do
+              assert_raise(NoMethodError) { @passport.saved_change_to_name? }
+              assert_raise(NoMethodError) { @passport.saved_change_to_photo? }
+              assert_raise(NoMethodError) { @passport.photo.saved_change_to_color? }
+            end
           }
         )
       end
@@ -434,6 +468,16 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
               should "not include the field" do
                 assert_equal({}, @passport.aggregate_attribute_saved_changes)
                 assert_equal({}, @passport.photo.aggregate_attribute_saved_changes)
+              end
+            end
+
+            context "when save still in progress" do
+              should "still mark aggregate_attribute_saved_changes? correctly" do
+                assert_equal({}, @passport.aggregate_attribute_saved_changes)
+                @passport.photo.color = true
+                @passport.photo.send(:start_save)
+
+                assert_equal({ "color" => [false, true] }, @passport.photo.aggregate_attribute_saved_changes)
               end
             end
           end


### PR DESCRIPTION
- Add before save functionality
- Allows saved change methods to be called even when save is in progress.
    - `#saved_changes?`
    - `#aggregate_attribute_saved_changes`
    - `#saved_change_to_{attribute}?`

Note: I tested this against web and was able to get the rails 5 tests green for `test/models/change_history/observers/*test.rb`!