### PR TITLE
TECH-5306 rails5 changed for autosave fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.3.2] - UNRELEASED
+### Fixed
+- Fixed an issue for Rails 5 where autosave associations weren't being recognized to be saved when the only changes on the object are aggregate attributes.
+  - This was primarily an issue with objects that utilize storing their aggregate data via LargeTextField and trying to have that object be autosaved by saving the object's parent relationship object.
+
+E.g.
+
+```ruby
+advertiser_campaign.future_terms.build_commission_budget_terms({...})
+advertiser_campaign.save! # This would not save the commission budget terms aggregate attribute on the future campaign terms
+```
+
 ## [2.3.1] - 2021-03-09
 ### Fixed
 - Fixed a bug where `Aggregate::AggregateStore` saved change methods would not show correct changes for
@@ -32,7 +44,7 @@ All notable changes to this project will be documented in this file.
 Ensures that the correct state is represented when a field is changed from and back to it's initial value.
 - Fixed a bug where changes to aggregate attributes during an aggregate schema fixup were being marked as changes.
   - These are seen as data migrations and thus are not changes to the model itself, but a transformation
-- Fixed a bug where `aggregate_has_many` attribute was not being marked as changed if one of its containing values changed  
+- Fixed a bug where `aggregate_has_many` attribute was not being marked as changed if one of its containing values changed
 
 ## [2.1.2] - 2020-11-23
 ### Fixed
@@ -85,6 +97,12 @@ callbacks defined by `ActiveRecord`
 ### Added
 - Added initial entry in ChangeLog (see README at this point for gem details)
 
+[2.3.2]: https://github.com/Invoca/aggregate/compare/v2.3.1...v2.3.2
+[2.3.1]: https://github.com/Invoca/aggregate/compare/v2.3.0...v2.3.1
+[2.3.0]: https://github.com/Invoca/aggregate/compare/v2.2.0...v2.3.0
+[2.2.0]: https://github.com/Invoca/aggregate/compare/v2.1.3...v2.2.0
+[2.1.3]: https://github.com/Invoca/aggregate/compare/v2.1.2...v2.1.3
+[2.1.2]: https://github.com/Invoca/aggregate/compare/v2.1.1...v2.1.2
 [2.1.1]: https://github.com/Invoca/aggregate/compare/v2.1.0...v2.1.1
 [2.1.0]: https://github.com/Invoca/aggregate/compare/v2.0.1...v2.1.0
 [2.0.1]: https://github.com/Invoca/aggregate/compare/v2.0.0...v2.0.1
@@ -95,4 +113,3 @@ callbacks defined by `ActiveRecord`
 [1.1]: https://github.com/Invoca/aggregate/compare/v1.0.1...v1.1
 [1.0.1]: https://github.com/Invoca/aggregate/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Invoca/aggregate/compare/v0.2.0...v1.0.0
-

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.3.1)
+    aggregate (2.3.2.pre.1)
       activerecord (>= 4.2, < 7)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -81,6 +81,15 @@ module Aggregate
       model_class.extend ClassMethods
     end
 
+    ActiveRecordHelpers::Version.if_version(
+      active_record_gt_4: -> do
+        def changed_for_autosave?
+          defined?(super) or raise NoMethodError, "undefined method 'changed_for_autosave?' for #{self}"
+          super || @changed
+        end
+      end
+    )
+
     def changed?
       (defined?(super) && super) || @changed
     end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.3.1"
+  VERSION = "2.3.2.pre.1"
 end

--- a/test/unit/aggregate_store_test.rb
+++ b/test/unit/aggregate_store_test.rb
@@ -162,7 +162,7 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
             end
 
             context "#changed_for_autosave?" do
-              context "when change triggered by a active record attribute change" do
+              context "when change triggered by an active record attribute change" do
                 should "respond appropriately" do
                   refute @passport.changed_for_autosave?
                   @passport.name = "blah"

--- a/test/unit/aggregate_store_test.rb
+++ b/test/unit/aggregate_store_test.rb
@@ -105,57 +105,121 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
               @passport.reload
             end
 
-            context "when change triggered by a active record attribute change" do
-              should "respond to saved_changes? appropriately" do
-                refute @passport.saved_changes?
-                @passport.name = "blah"
-                refute @passport.saved_changes?
-                @passport.save
-                assert @passport.saved_changes?
-                @passport.reload
-                refute @passport.saved_changes?
+            context "#saved_changes?" do
+              context "when change triggered by a active record attribute change" do
+                should "respond appropriately" do
+                  refute @passport.saved_changes?
+                  @passport.name = "blah"
+                  refute @passport.saved_changes?
+                  @passport.save
+                  assert @passport.saved_changes?
+                  @passport.reload
+                  refute @passport.saved_changes?
+                end
+              end
+
+              context "when change triggered by a aggregate attribute change" do
+                should "respond appropriately" do
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+                  @passport.save
+                  assert @passport.saved_changes?
+                  @passport.reload
+                  refute @passport.saved_changes?
+                end
+              end
+
+              context "when the aggregate value being assigned is same as before" do
+                should "not be marked" do
+                  visits = [ForeignVisit.new(country: "Spain"), ForeignVisit.new(country: "Japan")]
+                  @passport.foreign_visits = visits
+                  @passport.save
+                  assert @passport.saved_changes?
+                  @passport.foreign_visits = visits
+                  @passport.save
+                  refute @passport.saved_changes?
+                  # refute @passport.foreign_visits.first.saved_changes?    # instances think they are new because they were created above
+                end
+              end
+
+              context "when child attribute instance is not a active record object" do
+                should "respond appropriately " do
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Egypt"), ForeignVisit.new(country: "Russia")]
+                  @passport.save
+                  assert @passport.saved_changes?
+                  assert @passport.foreign_visits.first.saved_changes?
+                end
+              end
+
+              context "when save still in progress" do
+                should "be marked correctly" do
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+                  refute @passport.saved_changes?
+
+                  @passport.send(:start_save)
+                  assert @passport.saved_changes?
+                end
               end
             end
 
-            context "when change triggered by a aggregate attribute change" do
-              should "respond to saved_changes? appropriately" do
-                @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
-                @passport.save
-                assert @passport.saved_changes?
-                @passport.reload
-                refute @passport.saved_changes?
+            context "#changed_for_autosave?" do
+              context "when change triggered by a active record attribute change" do
+                should "respond appropriately" do
+                  refute @passport.changed_for_autosave?
+                  @passport.name = "blah"
+                  assert @passport.changed_for_autosave?
+
+                  @passport.save
+                  refute @passport.changed_for_autosave?
+                  @passport.reload
+                  refute @passport.changed_for_autosave?
+                end
               end
-            end
 
-            context "when the aggregate value being assigned is same as before" do
-              should "not mark saved_changes" do
-                visits = [ForeignVisit.new(country: "Spain"), ForeignVisit.new(country: "Japan")]
-                @passport.foreign_visits = visits
-                @passport.save
-                assert @passport.saved_changes?
-                @passport.foreign_visits = visits
-                @passport.save
-                refute @passport.saved_changes?
-                # refute @passport.foreign_visits.first.saved_changes?    # instances think they are new because they were created above
+              context "when change triggered by a aggregate attribute change" do
+                should "respond appropriately" do
+                  refute @passport.changed_for_autosave?
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+                  assert @passport.changed_for_autosave?
+
+                  @passport.save
+                  refute @passport.changed_for_autosave?
+                  @passport.reload
+                  refute @passport.changed_for_autosave?
+                end
               end
-            end
 
-            context "when child attribute instance is not a active record object" do
-              should "respond to saved_changes? appropriately " do
-                @passport.foreign_visits = [ForeignVisit.new(country: "Egypt"), ForeignVisit.new(country: "Russia")]
-                @passport.save
-                assert @passport.saved_changes?
-                assert @passport.foreign_visits.first.saved_changes?
+              context "when the aggregate value being assigned is same as before" do
+                should "not be marked" do
+                  visits = [ForeignVisit.new(country: "Spain"), ForeignVisit.new(country: "Japan")]
+                  @passport.foreign_visits = visits
+                  @passport.save
+                  refute @passport.changed_for_autosave?
+
+                  @passport.foreign_visits = visits
+                  refute @passport.changed_for_autosave?
+
+                  @passport.save
+                  refute @passport.changed_for_autosave?
+                end
               end
-            end
 
-            context "when save still in progress" do
-              should "still mark saved_changes? correctly" do
-                @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
-                refute @passport.saved_changes?
+              context "when child attribute instance does not have super defined (is not a active record object)" do
+                should "raise an error" do
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Egypt"), ForeignVisit.new(country: "Russia")]
+                  assert_raise(NoMethodError, /undefined method 'changed_for_autosave\?' for/) do
+                    @passport.foreign_visits.first.changed_for_autosave?
+                  end
+                end
+              end
 
-                @passport.send(:start_save)
-                assert @passport.saved_changes?
+              context "when save still in progress" do
+                should "be marked correctly" do
+                  @passport.foreign_visits = [ForeignVisit.new(country: "Canada"), ForeignVisit.new(country: "Mexico")]
+                  assert @passport.changed_for_autosave?
+
+                  @passport.send(:start_save)
+                  assert @passport.changed_for_autosave?
+                end
               end
             end
           end


### PR DESCRIPTION
WEB PR: https://github.com/Invoca/web/pull/15152

[TECH-5306](https://ringrevenue.atlassian.net/browse/TECH-5306)

## Description
From the README updates:
> - Fixed an issue for Rails 5 where autosave associations weren't being recognized to be saved when the only changes on the object are aggregate attributes.
>   - This was primarily an issue with objects that utilize storing their aggregate data via LargeTextField and trying to have that object be autosaved by saving the object's parent relationship object.
> 
> E.g.
> ```ruby
> advertiser_campaign.future_terms.build_commission_budget_terms({...})
> advertiser_campaign.save! # This would not save the commission budget terms aggregate attribute on the future campaign terms
> ```

## Changes
Main change is overriding `ActiveRecord::AutosaveAssociation#changed_for_autosave?` so that autosave will also occur if there are aggregate attribute changes.