### PR TITLE
TECH-5529: skip storing bitfield keys if default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.2] - 2021-04-26
+### Changed
+- Stopped writing bitfield attribute names to the database when the value is nil/default.
+
 ## [2.4.1] - 2021-04-12
 ### Fixed
 - Fixed an issue for Rails 5 where autosave associations weren't being recognized to be saved when the only changes on the object are aggregate attributes.
@@ -101,6 +105,7 @@ callbacks defined by `ActiveRecord`
 ### Added
 - Added initial entry in ChangeLog (see README at this point for gem details)
 
+[2.4.2]: https://github.com/Invoca/aggregate/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/Invoca/aggregate/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Invoca/aggregate/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/Invoca/aggregate/compare/v2.3.0...v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 All notable changes to this project will be documented in this file.
 
 ## [2.4.2] - 2021-04-26
+### Added
+- New option for attributes: `write_default_values` (default `false`)` that decides whether to write default values to the database.
 ### Changed
-- Stopped writing bitfield attribute names to the database when the value is nil/default.
+- `Aggregate::AggregateStorage#to_store`
+  - Default values for attributes will only be returned in the hash if `write_default_values` is set to true, even for non-nil values.
+  
 
 ## [2.4.1] - 2021-04-12
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.4.1)
+    aggregate (2.4.2)
       activerecord (>= 4.2, < 6.1)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.4.2)
+    aggregate (2.4.2.pre.1)
       activerecord (>= 4.2, < 6.1)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -287,11 +287,7 @@ module Aggregate
     end
 
     def store_value?(aggregate_attribute, value)
-      skip_on_default =
-        if aggregate_attribute.respond_to?(:skip_default?)
-          aggregate_attribute.skip_default?
-        end
-      !((aggregate_attribute.default.nil? || skip_on_default) && aggregate_attribute.default == value)
+      aggregate_attribute.default != value || aggregate_attribute.write_default_values?
     end
   end
 end

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -119,7 +119,7 @@ module Aggregate
 
         # Optimization: only write out values if they are not nil, if there is no schema migration and
         # the default value is nil. (Schema migrations and defaults depend on writing the value.)
-        if respond_to?(:data_schema_version) || !aa.default.nil? || !agg_value.nil?
+        if respond_to?(:data_schema_version) || store_value?(aa, agg_value)
           [aa.name, aa.to_store(agg_value)]
         end
       end
@@ -284,6 +284,14 @@ module Aggregate
       if @aggregate_save_in_progress
         save_changes
       end
+    end
+
+    def store_value?(aggregate_attribute, value)
+      skip_on_default =
+        if aggregate_attribute.respond_to?(:skip_default?)
+          aggregate_attribute.skip_default?
+        end
+      !((aggregate_attribute.default.nil? || skip_on_default) && aggregate_attribute.default == value)
     end
   end
 end

--- a/lib/aggregate/attribute/base.rb
+++ b/lib/aggregate/attribute/base.rb
@@ -8,11 +8,12 @@ module Aggregate
 
       def self.available_options
         [
-          :default,                  # The default value for this attribute.  Default is nil.
-          :limit,                    # Specifies the allowed values for this attribute.
-          :required,                 # If true, this attribute cannot be nil, default is false.
-          :force_validation,         # If true, this attribute will be validated even if it was not loaded, default is false.
-          :aggregate_db_storage_type # Attribute used to determine how to store certain types of attributes, default is nil.
+          :default,                   # The default value for this attribute.  Default is nil.
+          :limit,                     # Specifies the allowed values for this attribute.
+          :required,                  # If true, this attribute cannot be nil, default is false.
+          :force_validation,          # If true, this attribute will be validated even if it was not loaded, default is false.
+          :aggregate_db_storage_type, # Attribute used to determine how to store certain types of attributes, default is nil.
+          :write_default_values       # Defaults to true, used to skip storing default values when false.
         ]
       end
 
@@ -61,6 +62,10 @@ module Aggregate
 
       def assign_saved_changes(agg_value)
         agg_value.try(:set_saved_changes)
+      end
+
+      def write_default_values?
+        options[:write_default_values]
       end
     end
   end

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -40,6 +40,10 @@ class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
     []
   end
 
+  def skip_default?
+    true
+  end
+
   private
 
   def value_to_string(value)

--- a/lib/aggregate/attribute/bitfield.rb
+++ b/lib/aggregate/attribute/bitfield.rb
@@ -40,10 +40,6 @@ class Aggregate::Attribute::Bitfield < Aggregate::Attribute::Base
     []
   end
 
-  def skip_default?
-    true
-  end
-
   private
 
   def value_to_string(value)

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.4.2"
+  VERSION = "2.4.2.pre.1"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.4.1"
+  VERSION = "2.4.2"
 end

--- a/test/dummy/app/models/passport.rb
+++ b/test/dummy/app/models/passport.rb
@@ -9,7 +9,7 @@ class Passport < ActiveRecord::Base
   aggregate_attribute :state,            :string,   required: true
   aggregate_attribute :birthdate,        :datetime, required: true
   aggregate_attribute :height,           :decimal
-  aggregate_attribute :weight,           :decimal, default: 100
+  aggregate_attribute :weight,           :decimal, default: 100, write_default_values: true
   aggregate_attribute :photo,            "PassportPhoto"
   aggregate_has_many  :foreign_visits,   "ForeignVisit"
   aggregate_attribute :stamps,           :bitfield, limit: 10

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -72,7 +72,6 @@ class PassportTest < ActiveSupport::TestCase
           "city"           => "Santa Barbara",
           "foreign_visits" => [{ "country" => "Canada" }, { "country" => "Mexico" }],
           "gender"         => "female",
-          "stamps"         => nil,
           "state"          => "California",
           "weight"         => "100.0"
         }

--- a/test/unit/attribute/base_test.rb
+++ b/test/unit/attribute/base_test.rb
@@ -72,5 +72,9 @@ class Aggregate::Attribute::BaseTest < ActiveSupport::TestCase
       ad = Aggregate::AttributeHandler.factory("testme", "string", force_validation: true)
       assert ad.force_validation?
     end
+
+    should "return false for store_default_value?" do
+      refute Aggregate::AttributeHandler.factory("testme", "string", {}).write_default_values?
+    end
   end
 end

--- a/test/unit/attribute/bitfield_test.rb
+++ b/test/unit/attribute/bitfield_test.rb
@@ -73,4 +73,8 @@ class Aggregate::Attribute::BitfieldTest < ActiveSupport::TestCase
       Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4, mapping: { 't' => true, 'f' => true, ' ' => nil })
     end
   end
+
+  should "return true on skip_default?" do
+    assert @ad.skip_default?
+  end
 end

--- a/test/unit/attribute/bitfield_test.rb
+++ b/test/unit/attribute/bitfield_test.rb
@@ -5,7 +5,7 @@ require_relative '../../test_helper'
 class Aggregate::Attribute::BitfieldTest < ActiveSupport::TestCase
 
   setup do
-    @ad = Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4)
+    @ad = Aggregate::AttributeHandler.factory("testme", :bitfield, limit: 4, write_default_values: false)
     @default_bitfield_options = { mapping: { 't' => true, 'f' => false, ' ' => nil }, default: nil }
   end
 
@@ -74,7 +74,7 @@ class Aggregate::Attribute::BitfieldTest < ActiveSupport::TestCase
     end
   end
 
-  should "return true on skip_default?" do
-    assert @ad.skip_default?
+  should "return false on write_default_values? if set to false" do
+    refute @ad.write_default_values?
   end
 end


### PR DESCRIPTION
Bitfields are currently writing their keys in `to_store` even for default values. This is a small change to stop that from happening.