### PR TITLE
no-jira: fix bitfield storage bug, add empty? method to bitfield

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.4.2] - 2021-05-26
+### Fixed
+- Fixed a bug where bitfield attributes were unnecessarily storing nulls in the aggregate store when empty.
+
+
 ## [2.4.1] - 2021-04-12
 ### Fixed
 - Fixed an issue for Rails 5 where autosave associations weren't being recognized to be saved when the only changes on the object are aggregate attributes.
@@ -101,6 +106,7 @@ callbacks defined by `ActiveRecord`
 ### Added
 - Added initial entry in ChangeLog (see README at this point for gem details)
 
+[2.4.2]: https://github.com/Invoca/aggregate/compare/v2.4.1...v2.4.2
 [2.4.1]: https://github.com/Invoca/aggregate/compare/v2.4.0...v2.4.1
 [2.4.0]: https://github.com/Invoca/aggregate/compare/v2.3.1...v2.4.0
 [2.3.1]: https://github.com/Invoca/aggregate/compare/v2.3.0...v2.3.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,10 +6,9 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
-## [2.4.2] - 2021-05-26
+## [2.4.2] - 2021-05-27
 ### Fixed
 - Fixed a bug where bitfield attributes were unnecessarily storing nulls in the aggregate store when empty.
-
 
 ## [2.4.1] - 2021-04-12
 ### Fixed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.4.1)
+    aggregate (2.4.2.pre.gkent.0)
       activerecord (>= 4.2, < 6.1)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.4.2.pre.gkent.0)
+    aggregate (2.4.2)
       activerecord (>= 4.2, < 6.1)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/bitfield.rb
+++ b/lib/aggregate/bitfield.rb
@@ -77,5 +77,11 @@ module Aggregate
     def <=>(other)
       to_s <=> other.to_s
     end
+
+    def empty?
+      to_s == ""
+    end
+
+    alias nil? empty?
   end
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.4.2.pre.gkent.0"
+  VERSION = "2.4.2"
 end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.4.1"
+  VERSION = "2.4.2.pre.gkent.0"
 end

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -72,7 +72,6 @@ class PassportTest < ActiveSupport::TestCase
           "city"           => "Santa Barbara",
           "foreign_visits" => [{ "country" => "Canada" }, { "country" => "Mexico" }],
           "gender"         => "female",
-          "stamps"         => nil,
           "state"          => "California",
           "weight"         => "100.0"
         }

--- a/test/unit/bitfield_test.rb
+++ b/test/unit/bitfield_test.rb
@@ -89,6 +89,28 @@ class Aggregate::BitfieldTest < ActiveSupport::TestCase
       end
     end
 
+    context "#empty?" do
+      should "return true if string is empty" do
+        bitfield = Aggregate::Bitfield.with_options(@bitfield_options.merge(limit: 5)).new("")
+        assert_equal true, bitfield.empty?
+      end
+
+      should "return false if string is not empty" do
+        bitfield = Aggregate::Bitfield.with_options(@bitfield_options.merge(limit: 5)).new("tf t")
+        assert_equal false, bitfield.empty?
+      end
+    end
+
+    context "#nil?" do
+      should "alias to empty?" do
+        bitfield = Aggregate::Bitfield.with_options(@bitfield_options.merge(limit: 5)).new("tf t")
+        assert_equal false, bitfield.nil?
+
+        bitfield = Aggregate::Bitfield.with_options(@bitfield_options.merge(limit: 5)).new("")
+        assert_equal true, bitfield.nil?
+      end
+    end
+
     context "length limited classes" do
       should "allow values below the limit" do
         bitfield = Aggregate::Bitfield.with_options(@bitfield_options.merge(limit: 10)).new("")


### PR DESCRIPTION
Currently, empty bitfields are writing null values to the JSON storage. 

For example:
```{\"stamps\":null}```
