### PR TITLE
fix numericality validation to skip db checking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,12 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
-## [2.5.0] - Unreleased
+## [2.5.1] - 2024-08-05
+### Fixed
+- Replaced override of type_for_attribute with overriding ActiveRecord's numericality validation to just use ActiveModel's numericality validation.
+  - This fixes an issue where we were trying to reach out to the database for the precision of the columns.
+
+## [2.5.0] - 2024-07-01
 - Allow ActiveRecord versions >= 6.0
 - Require Ruby >= 3.1
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -15,5 +15,5 @@ gem 'rr',        '3.1.0'
 gem 'rubocop', require: false
 gem 'shoulda'
 gem 'sqlite3', "~> 1.4"
-gem 'test-unit', '3.6.2'
 gem 'test_after_commit', require: false
+gem 'test-unit', '3.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.5.0)
+    aggregate (2.5.1)
       activerecord (>= 6.0)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/aggregate.gemspec
+++ b/aggregate.gemspec
@@ -18,10 +18,10 @@ Gem::Specification.new do |s|
   s.required_ruby_version = ">= 3.1"
 
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
-  s.test_files = Dir["test/**/*"]
 
   s.add_dependency "activerecord",     ">= 6.0"
   s.add_dependency "encryptor",        "~> 3.0"
   s.add_dependency "invoca-utils",     "~> 0.3"
   s.add_dependency "large_text_field", ">= 1.0.2"
+  s.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/gemfiles/activerecord_6_0.gemfile
+++ b/gemfiles/activerecord_6_0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 6.0.0"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "bigdecimal"
@@ -13,8 +14,7 @@ gem "rr", "3.1.0"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3", "~> 1.4"
-gem "test-unit", "3.6.2"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 6.0.0"
+gem "test-unit", "3.6.2"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_6_1.gemfile
+++ b/gemfiles/activerecord_6_1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 6.1.0"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "bigdecimal"
@@ -13,8 +14,7 @@ gem "rr", "3.1.0"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3", "~> 1.4"
-gem "test-unit", "3.6.2"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 6.1.0"
+gem "test-unit", "3.6.2"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7_0.gemfile
+++ b/gemfiles/activerecord_7_0.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 7.0.0"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "bigdecimal"
@@ -13,8 +14,7 @@ gem "rr", "3.1.0"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3", "~> 1.4"
-gem "test-unit", "3.6.2"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 7.0.0"
+gem "test-unit", "3.6.2"
 
 gemspec path: "../"

--- a/gemfiles/activerecord_7_1.gemfile
+++ b/gemfiles/activerecord_7_1.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 7.1.0"
 gem "appraisal"
 gem "appraisal-matrix"
 gem "bigdecimal"
@@ -13,8 +14,7 @@ gem "rr", "3.1.0"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3", "~> 1.4"
-gem "test-unit", "3.6.2"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 7.1.0"
+gem "test-unit", "3.6.2"
 
 gemspec path: "../"

--- a/gemfiles/rails_5.gemfile
+++ b/gemfiles/rails_5.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 5.2"
 gem "appraisal"
 gem "bigdecimal"
 gem "jquery-rails"
@@ -12,8 +13,7 @@ gem "rr", "1.1.2"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3"
-gem "test-unit", "3.1.3"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 5.2"
+gem "test-unit", "3.1.3"
 
 gemspec path: "../"

--- a/gemfiles/rails_6.gemfile
+++ b/gemfiles/rails_6.gemfile
@@ -2,6 +2,7 @@
 
 source "https://rubygems.org"
 
+gem "activerecord", "~> 6.0", "< 6.1"
 gem "appraisal"
 gem "bigdecimal"
 gem "jquery-rails"
@@ -12,8 +13,7 @@ gem "rr", "1.1.2"
 gem "rubocop", require: false
 gem "shoulda"
 gem "sqlite3"
-gem "test-unit", "3.1.3"
 gem "test_after_commit", require: false
-gem "activerecord", "~> 6.0", "< 6.1"
+gem "test-unit", "3.1.3"
 
 gemspec path: "../"

--- a/lib/aggregate/aggregate_store.rb
+++ b/lib/aggregate/aggregate_store.rb
@@ -79,6 +79,7 @@ module Aggregate
 
     def self.included(model_class)
       attr_accessor :aggregate_list
+
       model_class.extend ClassMethods
     end
 

--- a/lib/aggregate/attribute/boolean.rb
+++ b/lib/aggregate/attribute/boolean.rb
@@ -15,7 +15,7 @@ module Aggregate
         self.class.convert_to_boolean(value)
       end
 
-      TRUE_VALUES = %w[1 t T true TRUE].to_set
+      TRUE_VALUES = ['1', 't', 'T', 'true', 'TRUE'].to_set
 
       def self.convert_to_boolean(value)
         if value.is_a?(::String)

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -27,8 +27,10 @@ module Aggregate
     class << self
       def aggregate_db_storage_type; end
 
-      # Needed in Rails 7.1 validations. `nil` is a valid return value.
-      def type_for_attribute(*); end
+      # Skips checking database for precision of float attributes.
+      def validates_numericality_of(*attr_names)
+        validates_with ActiveModel::Validations::NumericalityValidator, _merge_attributes(attr_names)
+      end
     end
 
     def initialize(arguments = {})
@@ -58,7 +60,7 @@ module Aggregate
     end
 
     def root_aggregate_owner
-      !aggregate_owner ? self : aggregate_owner.root_aggregate_owner
+      aggregate_owner ? aggregate_owner.root_aggregate_owner : self
     end
 
     def self.from_store(decoded_aggregate_store)

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -27,7 +27,7 @@ module Aggregate
     class << self
       def aggregate_db_storage_type; end
 
-      # Skips checking database for precision of float attributes.
+      # Skips checking database for precision of fields.
       def validates_numericality_of(*attr_names)
         validates_with ActiveModel::Validations::NumericalityValidator, _merge_attributes(attr_names)
       end

--- a/lib/aggregate/combined_string_field.rb
+++ b/lib/aggregate/combined_string_field.rb
@@ -3,6 +3,7 @@
 module Aggregate::CombinedStringField
   class CombinedStringField
     attr_accessor :attributes, :host_attribute
+
     def initialize(attributes, host_attribute)
       @attributes = attributes
       @host_attribute = host_attribute
@@ -66,7 +67,7 @@ module Aggregate::CombinedStringField
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
 
-    %w[read_attribute _read_attribute].each do |method_name|
+    ['read_attribute', '_read_attribute'].each do |method_name|
       define_method(method_name) do |name|
         if name.in?(attribute_list.map { |a| [a].flatten.first.to_s })
           send(name)

--- a/lib/aggregate/container.rb
+++ b/lib/aggregate/container.rb
@@ -91,7 +91,7 @@ module Aggregate
     end
 
     def reload(options = nil)
-      result = super(options)
+      result = super
       reset_cache_data
       result
     end

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.5.0"
+  VERSION = "2.5.1"
 end

--- a/test/aggregate_test.rb
+++ b/test/aggregate_test.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-require_relative './test_helper'
+require_relative 'test_helper'
 
 class AggregateTest < ActiveSupport::TestCase
   test "truth" do

--- a/test/dummy/config.ru
+++ b/test/dummy/config.ru
@@ -2,5 +2,5 @@
 
 # This file is used by Rack-based servers to start the application.
 
-require ::File.expand_path('../config/environment', __FILE__)
+require File.expand_path('config/environment', __dir__)
 run Dummy::Application

--- a/test/dummy/config/initializers/backtrace_silencers.rb
+++ b/test/dummy/config/initializers/backtrace_silencers.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # You can add backtrace silencers for libraries that you're using but don't wish to see in your backtraces.

--- a/test/dummy/config/initializers/inflections.rb
+++ b/test/dummy/config/initializers/inflections.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new inflection rules using the following format

--- a/test/dummy/config/initializers/mime_types.rb
+++ b/test/dummy/config/initializers/mime_types.rb
@@ -1,4 +1,5 @@
 # frozen_string_literal: true
+
 # Be sure to restart your server when you modify this file.
 
 # Add new mime types for use in respond_to blocks:

--- a/test/dummy/test/unit/passport_test.rb
+++ b/test/dummy/test/unit/passport_test.rb
@@ -32,7 +32,7 @@ class PassportTest < ActiveSupport::TestCase
       passport.save!
       passport = Passport.find(passport.id)
 
-      assert_equal %w[Canada Mexico], passport.foreign_visits.map(&:country)
+      assert_equal ['Canada', 'Mexico'], passport.foreign_visits.map(&:country)
     end
 
     should "be able to access bitfields" do

--- a/test/unit/aggregate_store_test.rb
+++ b/test/unit/aggregate_store_test.rb
@@ -6,6 +6,7 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
 
   class OwnerStub
     attr_accessor :change_called
+
     def set_changed
       @change_called = true
     end
@@ -13,6 +14,7 @@ class Aggregate::AggregateStoreTest < ActiveSupport::TestCase
 
   class ErrorsStub
     attr_accessor :messages
+
     def add(attr, message)
       (@messages ||= []) << [attr, message]
     end

--- a/test/unit/attribute/list_test.rb
+++ b/test/unit/attribute/list_test.rb
@@ -19,26 +19,26 @@ class Aggregate::Attribute::ListTest < ActiveSupport::TestCase
   should "handle basic marshalling" do
     ad = Aggregate::AttributeHandler.has_many_factory("testme", "string", {})
 
-    assert_equal %w[manny moe jack], ad.from_value(%w[manny moe jack])
-    assert_equal %w[manny moe jack], ad.from_value([:manny, "moe", "jack"])
+    assert_equal ['manny', 'moe', 'jack'], ad.from_value(['manny', 'moe', 'jack'])
+    assert_equal ['manny', 'moe', 'jack'], ad.from_value([:manny, "moe", "jack"])
 
-    assert_equal %w[manny moe jack], ad.to_store(%w[manny moe jack])
-    assert_equal %w[manny moe jack], ad.from_store(%w[manny moe jack])
+    assert_equal ['manny', 'moe', 'jack'], ad.to_store(['manny', 'moe', 'jack'])
+    assert_equal ['manny', 'moe', 'jack'], ad.from_store(['manny', 'moe', 'jack'])
   end
 
   should "delegate to the class for validation" do
     ad = Aggregate::AttributeHandler.has_many_factory("testme", "string", size: 10)
 
-    assert_equal [], ad.validation_errors(%w[manny moe jack])
+    assert_equal [], ad.validation_errors(['manny', 'moe', 'jack'])
 
     expected = ["is invalid"]
-    assert_equal expected, ad.validation_errors(%w[manny moe jack this_is_too_long])
+    assert_equal expected, ad.validation_errors(['manny', 'moe', 'jack', 'this_is_too_long'])
   end
 
   should "collapse errors to the base class if specified" do
     ad = Aggregate::AttributeHandler.has_many_factory("testme", "string", size: 10, collapse_errors: true)
 
-    assert_equal [], ad.validation_errors(%w[manny moe jack])
+    assert_equal [], ad.validation_errors(['manny', 'moe', 'jack'])
     expected = ["String is too long (maximum is 10 characters)"]
     assert_equal expected, ad.validation_errors(["manny", "moe", "jack", "this_is_too_long", "this is way too long too"])
   end

--- a/test/unit/bitfield_test.rb
+++ b/test/unit/bitfield_test.rb
@@ -44,7 +44,7 @@ class Aggregate::BitfieldTest < ActiveSupport::TestCase
       bitfield = Aggregate::Bitfield.with_options(@bitfield_options).new("")
 
       bitfield[10] = true
-      assert_equal([nil] * 10 + [true], (0..10).map { |i| bitfield[i] })
+      assert_equal(([nil] * 10) + [true], (0..10).map { |i| bitfield[i] })
     end
 
     should "trim trailing nils when reporting the string value" do

--- a/test/unit/combined_string_field_test.rb
+++ b/test/unit/combined_string_field_test.rb
@@ -80,7 +80,7 @@ class Aggregate::CombinedStringFieldTest < ActiveSupport::TestCase
       ex = assert_raises ArgumentError do
         @instance.first = "abc\n123"
       end
-      assert ex.message =~ /Cannot store newlines in combined fields storing \"abc\\n123\" in first/
+      assert ex.message =~ /Cannot store newlines in combined fields storing "abc\\n123" in first/
     end
 
     should "report if an attribute changed" do

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -71,11 +71,10 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     include Aggregate::Container
     store_aggregates_using_large_text_field
 
-    attr_accessor :fixup1_called, :fixup2_called, :value_at_fixup1, :upgraded_from_schema_version, :value_at_upgrade
+    attr_accessor :fixup1_called, :fixup2_called, :value_at_fixup1, :upgraded_from_schema_version, :value_at_upgrade, :aggregate_field_store
 
     # Overrides value from Aggregate::Container
     attr_accessor :aggregate_store
-    attr_accessor :aggregate_field_store
 
     def initialize(aggregate_store_json = nil, aggregate_field_store_json = nil)
       @aggregate_store       = aggregate_store_json
@@ -878,6 +877,7 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
           store_aggregates_using_large_text_field
 
           attr_accessor :storage, :old_storage
+
           aggregate_attribute :test_string, :string
         end
       end
@@ -918,6 +918,7 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
           store_aggregates_using :storage, migrate_from_storage_field: :old_storage
 
           attr_accessor :storage, :old_storage
+
           aggregate_attribute :test_string, :string
         end
       end


### PR DESCRIPTION
This was causing issues on shoulda-matchers version 4, where because this method was defined, it thought we were an ActiveRecord model and had access to `columns` method. This change now fixes the problem on Rails 7.1 but also fixes the issue we're seeing on shoulda 4