### PR TITLE
fix numericality validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.2] - 2024-08-06
+### Fixed
+- Support usage of `validates <field>, numericality: {...}` form of numericality option on Rails 6.1
+
 ## [2.5.1] - 2024-08-05
 ### Fixed
 - Replaced override of type_for_attribute with overriding ActiveRecord's numericality validation to just use ActiveModel's numericality validation.

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.5.1)
+    aggregate (2.5.2)
       activerecord (>= 6.0)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -20,6 +20,9 @@ module Aggregate
       include ActiveRecord::DefineCallbacks
     end
 
+    # Override ActiveRecord's NumericalityValidator with ActiveModel's to ensure we don't hit the database.
+    NumericalityValidator = ActiveModel::Validations::NumericalityValidator
+
     validate :validate_aggregates
 
     define_callbacks :before_validation, :aggregate_load, :aggregate_load_check_schema
@@ -27,9 +30,9 @@ module Aggregate
     class << self
       def aggregate_db_storage_type; end
 
-      # Skips checking database for precision of fields.
+      # Override ActiveRecord's validates_numericality_of to use ActiveModel's NumericalityValidator.
       def validates_numericality_of(*attr_names)
-        validates_with ActiveModel::Validations::NumericalityValidator, _merge_attributes(attr_names)
+        validates_with NumericalityValidator, _merge_attributes(attr_names)
       end
     end
 

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.5.1"
+  VERSION = "2.5.2"
 end

--- a/test/unit/base_test.rb
+++ b/test/unit/base_test.rb
@@ -4,6 +4,12 @@ require_relative '../test_helper'
 
 class Aggregate::BaseTest < ActiveSupport::TestCase
 
+  context "overrides" do
+    should "override numericality validator" do
+      assert_equal ActiveModel::Validations::NumericalityValidator, Aggregate::Base::NumericalityValidator
+    end
+  end
+
   context "Aggregate classes" do
     setup do
       @agg = Class.new(Aggregate::Base) { }

--- a/test/unit/container_test.rb
+++ b/test/unit/container_test.rb
@@ -64,7 +64,9 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
     attribute :shipped_at, :datetime
     attribute :postage_due, :decimal
 
+    # Creating duplicate validations to ensure we can handle both forms.
     validates_numericality_of :postage_due, greater_than_or_equal_to: 0, less_than_or_equal_to: 100
+    validates :postage_due, numericality: { greater_than_or_equal_to: 0, less_than_or_equal_to: 100 }
   end
 
   class TestPurchase < ActiveRecordStub
@@ -671,7 +673,7 @@ class Aggregate::ContainerTest < ActiveSupport::TestCase
       should "support rails validators" do
         @doc.first_shipment.postage_due = -1
         assert !@doc.first_shipment.valid?
-        assert_equal ["Postage due must be greater than or equal to 0"], @doc.first_shipment.errors.full_messages
+        assert_equal ["Postage due must be greater than or equal to 0"] * 2, @doc.first_shipment.errors.full_messages
       end
     end
 


### PR DESCRIPTION
Rails allows two ways to define a numericality validation on a model.
This change ensures we can handle both cases