### PR TITLE
WEB-7877: include ActiveModel::Validations in Aggregate::Base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ Note: This project adheres to [Semantic Versioning](https://semver.org/spec/v2.0
 
 All notable changes to this project will be documented in this file.
 
+## [2.5.3] - 2024-09-19
+### Fixed
+- Include `ActiveModel::Validations` in `Aggregate::Base` since `ActiveRecord::Validations` no longer includes it in rails 7.2.
+  - This is needed to include the `validate` method.
+
 ## [2.5.2] - 2024-08-06
 ### Fixed
 - Support usage of `validates <field>, numericality: {...}` form of numericality option on Rails 6.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    aggregate (2.5.2)
+    aggregate (2.5.3)
       activerecord (>= 6.0)
       encryptor (~> 3.0)
       invoca-utils (~> 0.3)
@@ -141,7 +141,7 @@ GEM
       minitest (>= 5.0)
       ruby-progressbar
     mutex_m (0.2.0)
-    net-imap (0.4.14)
+    net-imap (0.4.16)
       date
       net-protocol
     net-pop (0.1.2)

--- a/lib/aggregate/base.rb
+++ b/lib/aggregate/base.rb
@@ -11,6 +11,7 @@ module Aggregate
       define_method(method) { raise "call #{method} on containing class" }
     end
 
+    include ActiveModel::Validations
     include ActiveRecord::Validations
     include ActiveRecord::Callbacks
     include ActiveRecord::Reflection

--- a/lib/aggregate/version.rb
+++ b/lib/aggregate/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Aggregate
-  VERSION = "2.5.2"
+  VERSION = "2.5.3"
 end


### PR DESCRIPTION
Adds includes `ActiveModel::Validations` in `Aggregate::Base` to fix an error when running rails 7.2.

Aggregate::Base has the following includes:

```
include ActiveRecord::Validations
include ActiveRecord::Callbacks
```

In rails 7.1, ActiveRecord::Validations [used to include](https://github.com/rails/rails/blob/7-1-stable/activerecord/lib/active_record/validations.rb#L42) ActiveModel::Validations, which is where the validate method comes from. That include statement is no longer present in 7.2. `ActiveModel::Validations` needs to be included directly now to make use of the `validate` method.